### PR TITLE
Integrate NiMMbus community feedback

### DIFF
--- a/ckanext/nextgeoss/helpers.py
+++ b/ckanext/nextgeoss/helpers.py
@@ -20,3 +20,35 @@ def get_org_logo(id):
 def get_jira_script():
     jira_script = config.get('ckanext.nextgeoss.jira_issue_tracker')
     return jira_script
+
+
+def get_add_feedback_url(dataset):
+    """
+    Create the URL for adding feedback on a dataset via NiMMbus.
+
+    The ID and namespace are currently based on the CKAN instance, but
+    in the future they should be updated to use the original ID
+    and namespace of the dataset, once we've determined how they'll
+    be represented in the metadata.
+    """
+    feedback_url = 'http://www.opengis.uab.cat/nimmbus/index.htm?target_title={target_title}&target_code={target_code}&target_codespace={target_codespace}&page=ADDFEEDBACK&share_borrower_1=Anonymous'.format(
+        target_title=dataset['title'],
+        target_code=dataset['id'],
+        target_codespace=config.get('ckan.site_url'))
+
+    return feedback_url
+
+
+def get_feedback_url(dataset):
+    """
+    Get the feedback url for a specific dataset.
+
+    The namespace is currently set to the CKAN instance URL,
+    but it should be updated in the same way as the namespace
+    for `get_add_feedback_url()`.
+    """
+    feed_url = 'http://www.opengis.uab.cat/cgi-bin/nimmbus/nimmbus.cgi?SERVICE=WPS&REQUEST=EXECUTE&IDENTIFIER=NB_RESOURCE:ENUMERATE&LANGUAGE=eng&STARTINDEX=1&COUNT=100&FORMAT=text/xml&TYPE=FEEDBACK&TRG_TYPE_1=CITATION&TRG_FLD_1=CODE&TRG_VL_1={catalogue_id}&TRG_OPR_1=EQ&TRG_NXS_1=AND&TRG_TYPE_2=CITATION&TRG_FLD_2=NAMESPACE&TRG_VL_2={catalogue_namespace}&TRG_OPR_2=EQ'.format(
+        catalogue_id=dataset['id'],
+        catalogue_namespace=config.get('ckan.site_url'))
+
+    return feed_url

--- a/ckanext/nextgeoss/helpers.py
+++ b/ckanext/nextgeoss/helpers.py
@@ -37,18 +37,3 @@ def get_add_feedback_url(dataset):
         target_codespace=config.get('ckan.site_url'))
 
     return feedback_url
-
-
-def get_feedback_url(dataset):
-    """
-    Get the feedback url for a specific dataset.
-
-    The namespace is currently set to the CKAN instance URL,
-    but it should be updated in the same way as the namespace
-    for `get_add_feedback_url()`.
-    """
-    feed_url = 'http://www.opengis.uab.cat/cgi-bin/nimmbus/nimmbus.cgi?SERVICE=WPS&REQUEST=EXECUTE&IDENTIFIER=NB_RESOURCE:ENUMERATE&LANGUAGE=eng&STARTINDEX=1&COUNT=100&FORMAT=text/xml&TYPE=FEEDBACK&TRG_TYPE_1=CITATION&TRG_FLD_1=CODE&TRG_VL_1={catalogue_id}&TRG_OPR_1=EQ&TRG_NXS_1=AND&TRG_TYPE_2=CITATION&TRG_FLD_2=NAMESPACE&TRG_VL_2={catalogue_namespace}&TRG_OPR_2=EQ'.format(
-        catalogue_id=dataset['id'],
-        catalogue_namespace=config.get('ckan.site_url'))
-
-    return feed_url

--- a/ckanext/nextgeoss/plugin.py
+++ b/ckanext/nextgeoss/plugin.py
@@ -26,8 +26,7 @@ class NextgeossPlugin(plugins.SingletonPlugin):
             'nextgeoss_get_org_title': helpers.get_org_title,
             'nextgeoss_get_org_logo': helpers.get_org_logo,
             'nextgeoss_get_jira_script': helpers.get_jira_script,
-            'nextgeoss_get_add_feedback_url': helpers.get_add_feedback_url,
-            'nextgeoss_get_feedback_url': helpers.get_feedback_url
+            'nextgeoss_get_add_feedback_url': helpers.get_add_feedback_url
         }
 
     # IRoutes

--- a/ckanext/nextgeoss/plugin.py
+++ b/ckanext/nextgeoss/plugin.py
@@ -25,7 +25,9 @@ class NextgeossPlugin(plugins.SingletonPlugin):
         return {
             'nextgeoss_get_org_title': helpers.get_org_title,
             'nextgeoss_get_org_logo': helpers.get_org_logo,
-            'nextgeoss_get_jira_script': helpers.get_jira_script
+            'nextgeoss_get_jira_script': helpers.get_jira_script,
+            'nextgeoss_get_add_feedback_url': helpers.get_add_feedback_url,
+            'nextgeoss_get_feedback_url': helpers.get_feedback_url
         }
 
     # IRoutes

--- a/ckanext/nextgeoss/public/communityfeedback.js
+++ b/ckanext/nextgeoss/public/communityfeedback.js
@@ -1,0 +1,327 @@
+function getFeedbackUrl()
+// Get the URL for feedback feed.
+{
+  var url = $('#feedback_url').data("url");
+
+  return url
+}
+
+function loadFeedback()
+// Initiate the process of inserting the community feedback into the page.
+// Called when the page is first loaded.
+{
+  var url = getFeedbackUrl();
+
+  var context = {"action": "show"};
+
+  getFromNimmbus(url, showFeedback, context);
+}
+
+
+function showFeedback(feedbackFeed, context)
+// Show the feedback if there's feedback. If there's no feedback,
+// show a message instead.
+{
+  var entries = xmlToEntries(feedbackFeed);
+
+  if (entries.length == 0) {
+    $("#community-feedback-header").after('<p class="feedback-item" id="no-comments-yet">No comments yet. Be the first to leave feedback about this dataset.</p>')
+  } else {
+    $("#community-feedback-header").after('<ul class="feedback-list"><div id="start-feedback-items"></div><div id="end-feedback-items"></div></ul>');
+  
+    // Insert the core of each feedback item into the page and
+    // then request and insert the rest of it when it is available.
+    for(var i = 0, size = entries.length; i < size ; i++){
+
+      var entryDict = createBaseEntryDict(entries[i]);
+      renderFeedbackFeed(entryDict, context);
+
+      context = {
+        "action": "show",
+        "commentId": entryDict["commentId"]
+      };
+      getFromNimmbus(entryDict["link"], getFeedbackItem, context);
+
+    };
+  };
+}
+
+
+function createBaseEntryDict(entry)
+// Parse the entry XML from the feebdack feed and return a dictionary
+// with the important data.
+{
+  var title = entry.getElementsByTagName("title")[0].textContent;
+
+  var author = entry.getElementsByTagName("name")[0].textContent;
+
+  var updated = entry.getElementsByTagName("updated")[0].textContent;
+
+  var link = entry.getElementsByTagName("link")[0].getAttribute("href");
+
+  var commentId = link.split("RESOURCE=")[1].split("&USER=")[0];
+
+  var entryDict = {
+    "title": title,
+    "author": author,
+    "updated": updated,
+    "link": link,
+    "commentId": commentId
+  };
+
+  return entryDict
+}
+
+
+function getFromNimmbus(url, callback, context)
+// Retrieve a feedback feed or a feedback item from NiMMbus and then process
+// it with a callback function. The context is used by the callback function
+// to determine how the request data must be handled.
+{
+  var xhttp = new XMLHttpRequest();
+  
+  xhttp.onreadystatechange = function() {
+    if(xhttp.readyState === 4) {
+      if(xhttp.status === 200) { 
+        callback(xhttp, context);
+      } else {
+        console.log('An error occurred during your request: ' +  xhttp.status + ' ' + xhttp.statusText);
+      } 
+    }
+  }
+
+  xhttp.open("GET", url, true);
+  xhttp.send(null);
+}
+
+
+function getFeedbackItem(entry, context)
+// Parse an individual feedback item from NiMMbus and then pass the
+// resulting dictionary to another function to be rendered and inserted
+// into the page.
+{
+  var commentId = context["commentId"];
+
+  var feedback = entry.responseXML;
+
+  // Parse the feedback and insert fallback values if certain
+  // data is missing.
+  try {
+    var title = feedback.getElementsByTagName("mcc\:description")[0]
+      .getElementsByTagName("gco\:CharacterString")[0].textContent;
+  } catch(err) {
+    var title = "";
+  };
+
+  if (title.length == 0) {
+    title = "Untitled";
+  };
+
+  try {
+    var updated = feedback.getElementsByTagName("cit\:date")[0]
+      .getElementsByTagName("gco\:DateTime")[0].textContent;
+  } catch(err) {
+    var updated = "";
+  };
+
+  if (updated.length == 0) {
+    updated = "Undefined";
+  };
+
+  try {
+    var author = feedback.getElementsByTagName("cit\:CI_Individual")[0]
+      .getElementsByTagName("cit\:name")[0]
+      .getElementsByTagName("gco\:CharacterString")[0].textContent;
+  } catch(err) {
+    author = "";
+  };
+
+  if (author.length == 0) {
+    author = "Unknown";
+  };
+
+  try {
+    var abstract = feedback.getElementsByTagName("guf\:abstract")[0]
+      .getElementsByTagName("gco\:CharacterString")[0].textContent;
+  } catch(err) {
+    var abstract = "";
+  };
+
+  if (abstract.length == 0) {
+    abstract = "No abstract available"
+  };
+
+  try {
+    var rating = feedback.getElementsByTagName("guf\:GUF_RatingCode")[0]
+      .getAttribute("codeListValue");
+  } catch(err) {
+    var rating = "No rating available"
+  };
+
+  try {
+    var comment = feedback.getElementsByTagName("guf\:comment")[0]
+      .getElementsByTagName("gco\:CharacterString")[0].textContent;
+  } catch(err) {
+    var comment = ""
+  };
+
+  if (comment.length == 0) {
+    comment = "No comment available"
+  };
+
+  try {
+    var motivation = feedback
+      .getElementsByTagName("guf\:GUF_MotivationCode")[0]
+      .getAttribute("codeListValue");
+  } catch(err) {
+    var motivation = "Undefined";
+  };
+
+  var entryDict = {
+    "title": title,
+    "commentId": commentId,
+    "updated": updated,
+    "author": author,
+    "abstract": abstract,
+    "rating": rating,
+    "comment": comment
+  };
+
+  createFeedbackHtml(entryDict, commentId)
+}
+
+
+function renderFeedbackFeed(entryDict, context)
+// Create the HTML representing the core data for a feedback item
+// and insert it into the page. If action == show, we insert the item
+// at the bottom of the list of feedback items, creating a list in reverse
+// chronological order. If action == update, we insert the item at the top
+// of the existing list, mainaining the reverse chronological order.
+{
+  var feedItem = 
+    '<li data-commentId="'+entryDict['commentId']+'">\
+      <div class="feedback-item">\
+        <h4>'+entryDict['title']+'</h4>\
+        <p>'+entryDict['updated']+' by '+entryDict['author']+'</p>\
+        <div id="'+entryDict['commentId']+'" class="collapse"></div>\
+        <a href="#'+entryDict['commentId']+'" data-toggle="collapse" class="collapsed">\
+          <span class="if-collapsed">Read more</span>\
+          <span class="if-not-collapsed">Read less</span>\
+        </a>\
+      </div>\
+    </li>';
+  
+  if (context["action"] == "show") {
+    $("#end-feedback-items").before(feedItem);
+  } else if (context["action"] == "update") {
+    $("#start-feedback-items").after(feedItem);
+  };
+}
+
+
+function createFeedbackHtml(entryDict, commentId)
+// Create the HTML representing a feedback item's additional data
+// and insert it into the existing item in the list.
+{
+  var feedbackItem = 
+    '<p><span class="comment-part-name">Abstract: </span>'+entryDict['abstract']+'</p>\
+    <p><span class="comment-part-name">Rating: </span>'+entryDict['rating']+'</p>\
+    <p><span class="comment-part-name">Comment: </span>'+entryDict['comment']+'</p>\
+    <p><span class="comment-part-name">Motivation: </span>'+entryDict['motivation']+'</p>'
+
+  $("#"+entryDict["commentId"]).prepend(feedbackItem);
+}
+
+
+function showFeedbackForm(feedbackLink)
+// Open NiMMbus in a popup window. If the user enters feedback,
+// NiMMbus automatically closes the window. When the popup window
+// is closed (whether by NiMMbus or by the user if they choose not
+// make a comment), try to update feedback.
+{
+  var feedbackWindow = window
+    .open(feedbackLink, "connectWindow", "scrollbars=yes");
+
+  feedbackWindow.focus();
+
+  var monitor = setInterval(function() {
+
+    if (feedbackWindow.closed) {
+      var url = getFeedbackUrl();
+      getFromNimmbus(url, updateFeedback);
+      clearInterval(monitor);
+    }
+
+    }, 300);
+
+  return false;
+}
+
+
+function xmlToEntries(feedbackFeed)
+// Convert feedback feed to a list of entries.
+{
+  var xmlDoc = feedbackFeed.responseXML;
+  var entries = xmlDoc.getElementsByTagName("entry");
+
+  return entries
+}
+
+function updateFeedback(feedbackFeed)
+// Handle four cases:
+//
+// 1. If there are no entries in the feed and the no comments message is
+// present, there has been no change, so do nothing.
+// 2. If there are no entries in the feed and the no comments message is
+// not present, then all the previous comments have been deleted, so 
+// remove the old feedback list and then show the no comments message 
+// again by calling showFeedback().
+// 3. If there are entries in the feed and the no comments messages is
+// present, then the first comment or comments have just been added, so
+// remove the no comments message and show the feedback by calling 
+// showFeedback().
+// 4. If there are entries in the feed and the no comments message is not
+// present, then update the feedback with any new comments.
+{
+  var url = getFeedbackUrl();
+
+  var entries = xmlToEntries(feedbackFeed);
+
+  // 1.
+  if (entries.length == 0 && $("#no-comments-yet").length) {
+    return false;
+  // 2.
+  } else if (entries.length == 0 && !$("#no-comments-yet").length) {
+    $(".feedback-list").remove();
+    showFeedback(feedbackFeed, context={"action": "show"});
+  // 3.
+  } else if (entries.length != 0 && $("#no-comments-yet").length) {
+    $("#no-comments-yet").remove();
+    showFeedback(feedbackFeed, context={"action": "show"});
+  // 4.
+  } else if (entries.length != 0 && !$("#no-comments-yet").length) {
+
+    var topEntry = $("ul.feedback-list li").first();
+    var topCommentId = topEntry.attr("data-commentId");
+
+    for(var i = 0, size = entries.length; i < size ; i++){
+
+      var entryDict = createBaseEntryDict(entries[i]);
+
+      var commentId = entryDict["commentId"];
+
+      if (commentId != topCommentId) {
+        
+        context = {
+          "action": "update",
+          "commentId": commentId
+        };
+        renderFeedbackFeed(entryDict, context);
+        getFromNimmbus(entryDict["link"], getFeedbackItem, context);
+
+      } else {
+        break;
+      };
+    };
+  };
+}

--- a/ckanext/nextgeoss/public/communityfeedback.js
+++ b/ckanext/nextgeoss/public/communityfeedback.js
@@ -1,327 +1,326 @@
-function getFeedbackUrl()
-// Get the URL for feedback feed.
+function communityFeedback(catalogueID, catalogueNamespace, title)
+// Create a community feedback and insert it into the page.
 {
-  var url = $('#feedback_url').data("url");
+  this.catalogueID = catalogueID;
+  this.catalogueNamespace = catalogueNamespace;
+  this.title = title;
 
-  return url
-}
+  this.getFeedbackUrl = function() {
+    // Get the URL for feedback feed.
+    var url = 'http://www.opengis.uab.cat/cgi-bin/nimmbus/nimmbus.cgi?SERVICE=WPS&REQUEST=EXECUTE&IDENTIFIER=NB_RESOURCE:ENUMERATE&LANGUAGE=eng&STARTINDEX=1&COUNT=100&FORMAT=text/xml&TYPE=FEEDBACK&TRG_TYPE_1=CITATION&TRG_FLD_1=CODE&TRG_VL_1='+this.catalogueID+'&TRG_OPR_1=EQ&TRG_NXS_1=AND&TRG_TYPE_2=CITATION&TRG_FLD_2=NAMESPACE&TRG_VL_2='+this.catalogueNamespace+'&TRG_OPR_2=EQ'
+    return url
+  };
 
-function loadFeedback()
-// Initiate the process of inserting the community feedback into the page.
-// Called when the page is first loaded.
-{
-  var url = getFeedbackUrl();
+  this.getAddFeedbackUrl = function() {
+    // Get the URL for adding feedback.
+    var url = 'http://www.opengis.uab.cat/nimmbus/index.htm?target_title='+this.title+'&target_code='+this.catalogueID+'&target_codespace='+this.catalogueNamespace+'&page=ADDFEEDBACK&share_borrower_1=Anonymous'
+    return url
+  };
 
-  var context = {"action": "show"};
-
-  getFromNimmbus(url, showFeedback, context);
-}
-
-
-function showFeedback(feedbackFeed, context)
-// Show the feedback if there's feedback. If there's no feedback,
-// show a message instead.
-{
-  var entries = xmlToEntries(feedbackFeed);
-
-  if (entries.length == 0) {
-    $("#community-feedback-header").after('<p class="feedback-item" id="no-comments-yet">No comments yet. Be the first to leave feedback about this dataset.</p>')
-  } else {
-    $("#community-feedback-header").after('<ul class="feedback-list"><div id="start-feedback-items"></div><div id="end-feedback-items"></div></ul>');
-  
-    // Insert the core of each feedback item into the page and
-    // then request and insert the rest of it when it is available.
-    for(var i = 0, size = entries.length; i < size ; i++){
-
-      var entryDict = createBaseEntryDict(entries[i]);
-      renderFeedbackFeed(entryDict, context);
-
-      context = {
-        "action": "show",
-        "commentId": entryDict["commentId"]
-      };
-      getFromNimmbus(entryDict["link"], getFeedbackItem, context);
-
+  this.loadFeedback = function() {
+    // Initiate the process of inserting the community feedback into the page.
+    // Called when the page is first loaded.
+    var url = this.getFeedbackUrl();
+    var context = {
+      "action": "show",
     };
-  };
-}
-
-
-function createBaseEntryDict(entry)
-// Parse the entry XML from the feebdack feed and return a dictionary
-// with the important data.
-{
-  var title = entry.getElementsByTagName("title")[0].textContent;
-
-  var author = entry.getElementsByTagName("name")[0].textContent;
-
-  var updated = entry.getElementsByTagName("updated")[0].textContent;
-
-  var link = entry.getElementsByTagName("link")[0].getAttribute("href");
-
-  var commentId = link.split("RESOURCE=")[1].split("&USER=")[0];
-
-  var entryDict = {
-    "title": title,
-    "author": author,
-    "updated": updated,
-    "link": link,
-    "commentId": commentId
+    this.getFromNimmbus(url, showFeedback, context);
   };
 
-  return entryDict
-}
+  this.showFeedback = function(feedbackFeed, context) {
+    // Show the feedback if there's feedback. If there's no feedback,
+    // show a message instead.
+    var entries = this.xmlToEntries(feedbackFeed);
 
+    if (entries.length == 0) {
+      $("#community-feedback-anchor").after('<p class="feedback-item" id="no-comments-yet">No comments yet. Be the first to leave feedback about this dataset.</p>')
+    } else {
+      $("#community-feedback-anchor").after('<ul class="feedback-list"><div id="start-feedback-items"></div><div id="end-feedback-items"></div></ul>');
+    
+      // Insert the core of each feedback item into the page and
+      // then request and insert the rest of it when it is available.
+      for(var i = 0, size = entries.length; i < size ; i++){
 
-function getFromNimmbus(url, callback, context)
-// Retrieve a feedback feed or a feedback item from NiMMbus and then process
-// it with a callback function. The context is used by the callback function
-// to determine how the request data must be handled.
-{
-  var xhttp = new XMLHttpRequest();
-  
-  xhttp.onreadystatechange = function() {
-    if(xhttp.readyState === 4) {
-      if(xhttp.status === 200) { 
-        callback(xhttp, context);
-      } else {
-        console.log('An error occurred during your request: ' +  xhttp.status + ' ' + xhttp.statusText);
-      } 
-    }
-  }
+        var entryDict = this.createBaseEntryDict(entries[i]);
+        this.renderFeedbackFeed(entryDict, context);
 
-  xhttp.open("GET", url, true);
-  xhttp.send(null);
-}
-
-
-function getFeedbackItem(entry, context)
-// Parse an individual feedback item from NiMMbus and then pass the
-// resulting dictionary to another function to be rendered and inserted
-// into the page.
-{
-  var commentId = context["commentId"];
-
-  var feedback = entry.responseXML;
-
-  // Parse the feedback and insert fallback values if certain
-  // data is missing.
-  try {
-    var title = feedback.getElementsByTagName("mcc\:description")[0]
-      .getElementsByTagName("gco\:CharacterString")[0].textContent;
-  } catch(err) {
-    var title = "";
-  };
-
-  if (title.length == 0) {
-    title = "Untitled";
-  };
-
-  try {
-    var updated = feedback.getElementsByTagName("cit\:date")[0]
-      .getElementsByTagName("gco\:DateTime")[0].textContent;
-  } catch(err) {
-    var updated = "";
-  };
-
-  if (updated.length == 0) {
-    updated = "Undefined";
-  };
-
-  try {
-    var author = feedback.getElementsByTagName("cit\:CI_Individual")[0]
-      .getElementsByTagName("cit\:name")[0]
-      .getElementsByTagName("gco\:CharacterString")[0].textContent;
-  } catch(err) {
-    author = "";
-  };
-
-  if (author.length == 0) {
-    author = "Unknown";
-  };
-
-  try {
-    var abstract = feedback.getElementsByTagName("guf\:abstract")[0]
-      .getElementsByTagName("gco\:CharacterString")[0].textContent;
-  } catch(err) {
-    var abstract = "";
-  };
-
-  if (abstract.length == 0) {
-    abstract = "No abstract available"
-  };
-
-  try {
-    var rating = feedback.getElementsByTagName("guf\:GUF_RatingCode")[0]
-      .getAttribute("codeListValue");
-  } catch(err) {
-    var rating = "No rating available"
-  };
-
-  try {
-    var comment = feedback.getElementsByTagName("guf\:comment")[0]
-      .getElementsByTagName("gco\:CharacterString")[0].textContent;
-  } catch(err) {
-    var comment = ""
-  };
-
-  if (comment.length == 0) {
-    comment = "No comment available"
-  };
-
-  try {
-    var motivation = feedback
-      .getElementsByTagName("guf\:GUF_MotivationCode")[0]
-      .getAttribute("codeListValue");
-  } catch(err) {
-    var motivation = "Undefined";
-  };
-
-  var entryDict = {
-    "title": title,
-    "commentId": commentId,
-    "updated": updated,
-    "author": author,
-    "abstract": abstract,
-    "rating": rating,
-    "comment": comment
-  };
-
-  createFeedbackHtml(entryDict, commentId)
-}
-
-
-function renderFeedbackFeed(entryDict, context)
-// Create the HTML representing the core data for a feedback item
-// and insert it into the page. If action == show, we insert the item
-// at the bottom of the list of feedback items, creating a list in reverse
-// chronological order. If action == update, we insert the item at the top
-// of the existing list, mainaining the reverse chronological order.
-{
-  var feedItem = 
-    '<li data-commentId="'+entryDict['commentId']+'">\
-      <div class="feedback-item">\
-        <h4>'+entryDict['title']+'</h4>\
-        <p>'+entryDict['updated']+' by '+entryDict['author']+'</p>\
-        <div id="'+entryDict['commentId']+'" class="collapse"></div>\
-        <a href="#'+entryDict['commentId']+'" data-toggle="collapse" class="collapsed">\
-          <span class="if-collapsed">Read more</span>\
-          <span class="if-not-collapsed">Read less</span>\
-        </a>\
-      </div>\
-    </li>';
-  
-  if (context["action"] == "show") {
-    $("#end-feedback-items").before(feedItem);
-  } else if (context["action"] == "update") {
-    $("#start-feedback-items").after(feedItem);
-  };
-}
-
-
-function createFeedbackHtml(entryDict, commentId)
-// Create the HTML representing a feedback item's additional data
-// and insert it into the existing item in the list.
-{
-  var feedbackItem = 
-    '<p><span class="comment-part-name">Abstract: </span>'+entryDict['abstract']+'</p>\
-    <p><span class="comment-part-name">Rating: </span>'+entryDict['rating']+'</p>\
-    <p><span class="comment-part-name">Comment: </span>'+entryDict['comment']+'</p>\
-    <p><span class="comment-part-name">Motivation: </span>'+entryDict['motivation']+'</p>'
-
-  $("#"+entryDict["commentId"]).prepend(feedbackItem);
-}
-
-
-function showFeedbackForm(feedbackLink)
-// Open NiMMbus in a popup window. If the user enters feedback,
-// NiMMbus automatically closes the window. When the popup window
-// is closed (whether by NiMMbus or by the user if they choose not
-// make a comment), try to update feedback.
-{
-  var feedbackWindow = window
-    .open(feedbackLink, "connectWindow", "scrollbars=yes");
-
-  feedbackWindow.focus();
-
-  var monitor = setInterval(function() {
-
-    if (feedbackWindow.closed) {
-      var url = getFeedbackUrl();
-      getFromNimmbus(url, updateFeedback);
-      clearInterval(monitor);
-    }
-
-    }, 300);
-
-  return false;
-}
-
-
-function xmlToEntries(feedbackFeed)
-// Convert feedback feed to a list of entries.
-{
-  var xmlDoc = feedbackFeed.responseXML;
-  var entries = xmlDoc.getElementsByTagName("entry");
-
-  return entries
-}
-
-function updateFeedback(feedbackFeed)
-// Handle four cases:
-//
-// 1. If there are no entries in the feed and the no comments message is
-// present, there has been no change, so do nothing.
-// 2. If there are no entries in the feed and the no comments message is
-// not present, then all the previous comments have been deleted, so 
-// remove the old feedback list and then show the no comments message 
-// again by calling showFeedback().
-// 3. If there are entries in the feed and the no comments messages is
-// present, then the first comment or comments have just been added, so
-// remove the no comments message and show the feedback by calling 
-// showFeedback().
-// 4. If there are entries in the feed and the no comments message is not
-// present, then update the feedback with any new comments.
-{
-  var url = getFeedbackUrl();
-
-  var entries = xmlToEntries(feedbackFeed);
-
-  // 1.
-  if (entries.length == 0 && $("#no-comments-yet").length) {
-    return false;
-  // 2.
-  } else if (entries.length == 0 && !$("#no-comments-yet").length) {
-    $(".feedback-list").remove();
-    showFeedback(feedbackFeed, context={"action": "show"});
-  // 3.
-  } else if (entries.length != 0 && $("#no-comments-yet").length) {
-    $("#no-comments-yet").remove();
-    showFeedback(feedbackFeed, context={"action": "show"});
-  // 4.
-  } else if (entries.length != 0 && !$("#no-comments-yet").length) {
-
-    var topEntry = $("ul.feedback-list li").first();
-    var topCommentId = topEntry.attr("data-commentId");
-
-    for(var i = 0, size = entries.length; i < size ; i++){
-
-      var entryDict = createBaseEntryDict(entries[i]);
-
-      var commentId = entryDict["commentId"];
-
-      if (commentId != topCommentId) {
-        
         context = {
-          "action": "update",
-          "commentId": commentId
+          "action": "show",
+          "commentId": entryDict["commentId"]
         };
-        renderFeedbackFeed(entryDict, context);
-        getFromNimmbus(entryDict["link"], getFeedbackItem, context);
 
-      } else {
-        break;
+        this.getFromNimmbus(entryDict["link"], getFeedbackItem, context);
+
       };
     };
   };
-}
+
+  this.createBaseEntryDict = function(entry) {
+    // Parse the entry XML from the feebdack feed and return a dictionary
+    // with the important data.
+    var title = entry.getElementsByTagName("title")[0].textContent;
+
+    var author = entry.getElementsByTagName("name")[0].textContent;
+
+    var updated = entry.getElementsByTagName("updated")[0].textContent;
+
+    var link = entry.getElementsByTagName("link")[0].getAttribute("href");
+
+    var commentId = link.split("RESOURCE=")[1].split("&USER=")[0];
+
+    var entryDict = {
+      "title": title,
+      "author": author,
+      "updated": updated,
+      "link": link,
+      "commentId": commentId
+    };
+
+    return entryDict
+  };
+
+  this.getFromNimmbus = function(url, callback, context) {
+    // Retrieve a feedback feed or a feedback item from NiMMbus and then process
+    // it with a callback function. The context is used by the callback function
+    // to determine how the request data must be handled.
+    var xhttp = new XMLHttpRequest();
+    
+    xhttp.onreadystatechange = function() {
+      if(xhttp.readyState === 4) {
+        if(xhttp.status === 200) { 
+          callback(xhttp, context);
+        } else {
+          console.log('An error occurred during your request: ' 
+            +  xhttp.status + ' ' + xhttp.statusText);
+        } 
+      }
+    }
+
+    xhttp.open("GET", url, true);
+    xhttp.send(null);
+  };
+
+  this.getFeedbackItem = function(entry, context) {
+    // Parse an individual feedback item from NiMMbus and then pass the
+    // resulting dictionary to another function to be rendered and inserted
+    // into the page.
+    var commentId = context["commentId"];
+
+    var feedback = entry.responseXML;
+
+    // Parse the feedback and insert fallback values if certain
+    // data is missing.
+    try {
+      var title = feedback.getElementsByTagName("mcc\:description")[0]
+        .getElementsByTagName("gco\:CharacterString")[0].textContent;
+    } catch(err) {
+      var title = "";
+    };
+
+    if (title.length == 0) {
+      title = "Untitled";
+    };
+
+    try {
+      var updated = feedback.getElementsByTagName("cit\:date")[0]
+        .getElementsByTagName("gco\:DateTime")[0].textContent;
+    } catch(err) {
+      var updated = "";
+    };
+
+    if (updated.length == 0) {
+      updated = "Undefined";
+    };
+
+    try {
+      var author = feedback.getElementsByTagName("cit\:CI_Individual")[0]
+        .getElementsByTagName("cit\:name")[0]
+        .getElementsByTagName("gco\:CharacterString")[0].textContent;
+    } catch(err) {
+      author = "";
+    };
+
+    if (author.length == 0) {
+      author = "Unknown";
+    };
+
+    try {
+      var abstract = feedback.getElementsByTagName("guf\:abstract")[0]
+        .getElementsByTagName("gco\:CharacterString")[0].textContent;
+    } catch(err) {
+      var abstract = "";
+    };
+
+    if (abstract.length == 0) {
+      abstract = "No abstract available"
+    };
+
+    try {
+      var rating = feedback.getElementsByTagName("guf\:GUF_RatingCode")[0]
+        .getAttribute("codeListValue");
+    } catch(err) {
+      var rating = "No rating available"
+    };
+
+    try {
+      var comment = feedback.getElementsByTagName("guf\:comment")[0]
+        .getElementsByTagName("gco\:CharacterString")[0].textContent;
+    } catch(err) {
+      var comment = ""
+    };
+
+    if (comment.length == 0) {
+      comment = "No comment available"
+    };
+
+    try {
+      var motivation = feedback
+        .getElementsByTagName("guf\:GUF_MotivationCode")[0]
+        .getAttribute("codeListValue");
+    } catch(err) {
+      var motivation = "Undefined";
+    };
+
+    var entryDict = {
+      "title": title,
+      "commentId": commentId,
+      "updated": updated,
+      "author": author,
+      "abstract": abstract,
+      "rating": rating,
+      "comment": comment
+    };
+
+    this.createFeedbackHtml(entryDict, commentId)
+  };
+
+  this.renderFeedbackFeed = function(entryDict, context) {
+    // Create the HTML representing the core data for a feedback item
+    // and insert it into the page. If action == show, we insert the item
+    // at the bottom of the list of feedback items, creating a list in reverse
+    // chronological order. If action == update, we insert the item at the top
+    // of the existing list, mainaining the reverse chronological order.
+    var feedItem = 
+      '<li data-commentId="'+entryDict['commentId']+'">\
+        <div class="feedback-item">\
+          <h4>'+entryDict['title']+'</h4>\
+          <p>'+entryDict['updated']+' by '+entryDict['author']+'</p>\
+          <div id="'+entryDict['commentId']+'" class="collapse"></div>\
+          <a href="#'+entryDict['commentId']+'" data-toggle="collapse" class="collapsed">\
+            <span class="if-collapsed">Read more</span>\
+            <span class="if-not-collapsed">Read less</span>\
+          </a>\
+        </div>\
+      </li>';
+    
+    if (context["action"] == "show") {
+      $("#end-feedback-items").before(feedItem);
+    } else if (context["action"] == "update") {
+      $("#start-feedback-items").after(feedItem);
+    };
+  };
+
+  this.createFeedbackHtml = function(entryDict, commentId) {
+    // Create the HTML representing a feedback item's additional data
+    // and insert it into the existing item in the list.
+    var feedbackItem = 
+      '<p><span class="comment-part-name">Abstract: </span>'+entryDict['abstract']+'</p>\
+      <p><span class="comment-part-name">Rating: </span>'+entryDict['rating']+'</p>\
+      <p><span class="comment-part-name">Comment: </span>'+entryDict['comment']+'</p>\
+      <p><span class="comment-part-name">Motivation: </span>'+entryDict['motivation']+'</p>'
+
+    $("#"+entryDict["commentId"]).prepend(feedbackItem);
+  };
+
+  this.showFeedbackForm = function() {
+    // Open NiMMbus in a popup window. If the user enters feedback,
+    // NiMMbus automatically closes the window. When the popup window
+    // is closed (whether by NiMMbus or by the user if they choose not
+    // make a comment), try to update feedback.
+    var feedbackWindow = window
+      .open(this.getAddFeedbackUrl(), "connectWindow", "scrollbars=yes");
+
+    feedbackWindow.focus();
+
+    var monitor = setInterval(function() {
+
+      if (feedbackWindow.closed) {
+        var url = this.getFeedbackUrl();
+        getFromNimmbus(url, updateFeedback);
+        clearInterval(monitor);
+      }
+
+      }, 300);
+
+    return false;
+  };
+
+  this.xmlToEntries = function(feedbackFeed) {
+    // Convert feedback feed to a list of entries.
+    var xmlDoc = feedbackFeed.responseXML;
+    var entries = xmlDoc.getElementsByTagName("entry");
+
+    return entries
+  };
+
+  this.updateFeedback = function(feedbackFeed, url) {
+    // Handle four cases:
+    //
+    // 1. If there are no entries in the feed and the no comments message is
+    // present, there has been no change, so do nothing.
+    // 2. If there are no entries in the feed and the no comments message is
+    // not present, then all the previous comments have been deleted, so 
+    // remove the old feedback list and then show the no comments message 
+    // again by calling showFeedback().
+    // 3. If there are entries in the feed and the no comments messages is
+    // present, then the first comment or comments have just been added, so
+    // remove the no comments message and show the feedback by calling 
+    // showFeedback().
+    // 4. If there are entries in the feed and the no comments message is not
+    // present, then update the feedback with any new comments.
+    var entries = this.xmlToEntries(feedbackFeed);
+
+    // 1.
+    if (entries.length == 0 && $("#no-comments-yet").length) {
+      return false;
+    // 2.
+    } else if (entries.length == 0 && !$("#no-comments-yet").length) {
+      $(".feedback-list").remove();
+      showFeedback(feedbackFeed, context={"action": "show"});
+    // 3.
+    } else if (entries.length != 0 && $("#no-comments-yet").length) {
+      $("#no-comments-yet").remove();
+      this.showFeedback(feedbackFeed, context={"action": "show"});
+    // 4.
+    } else if (entries.length != 0 && !$("#no-comments-yet").length) {
+
+      var topEntry = $("ul.feedback-list li").first();
+      var topCommentId = topEntry.attr("data-commentId");
+
+      for(var i = 0, size = entries.length; i < size ; i++){
+
+        var entryDict = this.createBaseEntryDict(entries[i]);
+
+        var commentId = entryDict["commentId"];
+
+        if (commentId != topCommentId) {
+          
+          context = {
+            "action": "update",
+            "commentId": commentId
+          };
+          this.renderFeedbackFeed(entryDict, context);
+          this.getFromNimmbus(entryDict["link"], getFeedbackItem, context);
+
+        } else {
+          break;
+        };
+      };
+    };
+  };
+
+  // Add the add feedback button to the page.
+  $("#community-feedback-anchor").after('<div id="feedback-button-center"><a href="#community-feedback" onclick="javascript:showFeedbackForm();" class="btn btn-primary">Add feedback</a></div>');
+
+  return this.loadFeedback()
+} 

--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -1022,3 +1022,41 @@ button.btn.btn-navbar {
     width: auto !important;
   }
 }
+
+.feedback-list {
+  list-style-type: none;
+  margin-top: 30px;
+  margin-left: 0;
+  padding: 0;
+}
+
+.feedback-item {
+  margin-bottom: 20px;
+}
+.comment-part-name {
+  font-style: italic;
+}
+
+[data-toggle="collapse"].collapsed .if-not-collapsed {
+  display: none;
+}
+[data-toggle="collapse"]:not(.collapsed) .if-collapsed {
+  display: none;
+}
+
+#feedback-button-center {
+  text-align: center;
+}
+
+.collapse {
+  position:relative;
+  height:0;
+  overflow:hidden;
+  -webkit-transition:height 0.35s ease;
+  -moz-transition:height 0.35s ease;
+  -o-transition:height 0.35s ease;
+  transition:height 0.35s ease;
+}
+.collapse.in {
+  height:auto;
+}

--- a/ckanext/nextgeoss/templates/base.html
+++ b/ckanext/nextgeoss/templates/base.html
@@ -19,4 +19,5 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/latest/css/font-awesome.min.css" />
   <script src="/jquery.min.js" type="text/javascript"></script>
   <script src="/dropdown.js" type="text/javascript"></script>
+  <script src="/communityfeedback.js" type="text/javascript"></script>
 {% endblock %}

--- a/ckanext/nextgeoss/templates/package/read.html
+++ b/ckanext/nextgeoss/templates/package/read.html
@@ -59,6 +59,10 @@
     {% snippet "package/snippets/additional_info.html", pkg_dict=pkg %}
   {% endblock %}
 
+  {% block dataset_feedback %}
+    {% snippet "package/snippets/community_feedback.html", pkg=pkg %}
+  {% endblock %}
+
   {% snippet "snippets/social_inline.html" %}
 
   </div>

--- a/ckanext/nextgeoss/templates/package/snippets/community_feedback.html
+++ b/ckanext/nextgeoss/templates/package/snippets/community_feedback.html
@@ -1,0 +1,18 @@
+<section class="additional-info" id="community-feedback">
+
+  <h3 id="community-feedback-header"><i class="fa fa-pencil-square-o" aria-hidden="true"></i> {{ _('Community Feedback') }}</h3>
+
+  <!--Get the URL for the package's feedback feed and 
+  make it available to the communityfeedback script -->
+  {% set feedback_url = h.nextgeoss_get_feedback_url(pkg) %}
+  <meta id="feedback_url" data-url="{{ feedback_url }}">
+
+  <!-- Display the community feedback if available -->
+  <script>loadFeedback();</script>
+
+  <!-- Open the add feedback window in a popup window and 
+  reload the page when the popup is closed in order to cause
+  the user's new comment to be displayed -->
+  <div id="feedback-button-center"><a href="#community-feedback" onclick="javascript:showFeedbackForm('{{ h.nextgeoss_get_add_feedback_url(pkg) }}');" class="btn btn-primary">{{ _('Add feedback') }}</a></div>
+
+</section>

--- a/ckanext/nextgeoss/templates/package/snippets/community_feedback.html
+++ b/ckanext/nextgeoss/templates/package/snippets/community_feedback.html
@@ -2,17 +2,17 @@
 
   <h3 id="community-feedback-header"><i class="fa fa-pencil-square-o" aria-hidden="true"></i> {{ _('Community Feedback') }}</h3>
 
-  <!--Get the URL for the package's feedback feed and 
-  make it available to the communityfeedback script -->
-  {% set feedback_url = h.nextgeoss_get_feedback_url(pkg) %}
-  <meta id="feedback_url" data-url="{{ feedback_url }}">
+  <!--To be used unly until the metadata schema (and thus the real catalogue namespace, etc.) are determined.
+  This two-step processed is only used to avoid creating another helper function that would just be removed later -->
+  {% set catalogue_url = h.get_site_protocol_and_host() %}
+  {% set catalogue_namespace = '%s://%s'|format(catalogue_url[0], catalogue_url[1]) %}
+  {% set catalogue_id = pkg['id'] %}
+  {% set title = pkg.get('title', pkg['name']) %}
 
   <!-- Display the community feedback if available -->
-  <script>loadFeedback();</script>
-
-  <!-- Open the add feedback window in a popup window and 
-  reload the page when the popup is closed in order to cause
-  the user's new comment to be displayed -->
-  <div id="feedback-button-center"><a href="#community-feedback" onclick="javascript:showFeedbackForm('{{ h.nextgeoss_get_add_feedback_url(pkg) }}');" class="btn btn-primary">{{ _('Add feedback') }}</a></div>
+  <div id = "community-feedback-block">
+    <div id="community-feedback-anchor"></div>
+    <script>communityFeedback("{{ catalogue_id }}", "{{ catalogue_namespace }}", "{{ title }}");</script>
+  </div>
 
 </section>


### PR DESCRIPTION
Users can add feedback on a specific dataset via a popup window containing the NiMMbus website. Most of the functionality is supplied by a JavaScript script that updates a new section of the dataset page containing the community feedback.

Creating feedback in NiMMbus is a two-step process: users have to create a citation for the dataset (or whatever object they are commenting on) and then write the feedback itself. When a user clicks on the `Add feedback` button, NiMMbus automatically creates the citation using the parameters supplied via the URL associated with the button. The user then logs in or creates an account and is then able to submit their feedback. If they submit feedback, the popup window closes automatically and the div containing the comments is automatically updated.

The feedback feed and the individual feedback items are loaded asynchronously so that the community feedback doesn't prevent the page from loading. The feedback feed does not contain all the information (like the abstract, motivation, and rating) associated with a feedback item, so additional requests are necessary in order to show all the feedback content.

This implementation requests all the data about each feedback item when the page loads. An alternate approach would be to request the additional information about a given feedback item only when the user clicks on the `Read more` button; however, it seemed like that approach would deliver a less responsive user experience.

There are some feedback fields that are not currently parsed and displayed, like `purpose`. They were not included in the list of "interesting" fields, so they're not included here either, but adding them in the future would be trivial.

The `Read more`/`Read less` buttons only work once with my version of Bootstrap/collapse.js. That issue should be resolved with a newer version of Bootstrap.