### PR TITLE
Use HTTPS when connecting to NiMMbus

### DIFF
--- a/ckanext/nextgeoss/public/communityfeedback.js
+++ b/ckanext/nextgeoss/public/communityfeedback.js
@@ -114,16 +114,15 @@ function communityFeedback(catalogueID, catalogueNamespace, title)
       var updated = feedback.getElementsByTagName("cit\:date")[0]
         .getElementsByTagName("gco\:DateTime")[0].textContent;
     } catch(err) {
-      var updated = "";
-    };
-
-    if (updated.length == 0) {
       try {
-        updated = feedback.getElementsByTagName("date")[0]
+        var updated = feedback.getElementsByTagName("date")[0]
           .getElementsByTagName("DateTime")[0].textContent;
       } catch(err) {
-        updated = "Undefined";
+        var updated = "";
       };
+    };
+    if (updated.length == 0) {
+      updated = "Undefined";
     };
 
     try {
@@ -131,84 +130,95 @@ function communityFeedback(catalogueID, catalogueNamespace, title)
         .getElementsByTagName("cit\:name")[0]
         .getElementsByTagName("gco\:CharacterString")[0].textContent;
     } catch(err) {
-      author = "";
-    };
-
-    if (author.length == 0) {
       try {
-        author = feedback.getElementsByTagName("CI_Individual")[0]
+        var author = feedback.getElementsByTagName("CI_Individual")[0]
           .getElementsByTagName("name")[0]
           .getElementsByTagName("CharacterString")[0].textContent;
       } catch(err) {
-        author = "Unknown";
+        var author = "";
       };
+    };
+    if (author.length == 0) {
+      author = "Unknown";
     };
 
     try {
       var abstract = feedback.getElementsByTagName("guf\:abstract")[0]
         .getElementsByTagName("gco\:CharacterString")[0].textContent;
     } catch(err) {
-      var abstract = "";
-    };
-
-    if (abstract.length == 0) {
       try {
         abstract = feedback.getElementsByTagName("abstract")[0]
           .getElementsByTagName("CharacterString")[0].textContent;
       } catch(err) {
-        abstract = "No abstract available";
+        abstract = "";
       };
+    };
+    if (abstract.length == 0) {
+    abstract = "No abstract available"
     };
 
     try {
       var rating = feedback.getElementsByTagName("guf\:GUF_RatingCode")[0]
         .getAttribute("codeListValue");
     } catch(err) {
-      var rating = ""
-    };
-
-    if (rating.length == 0) {
       try {
-        rating = feedback.getElementsByTagName("GUF_RatingCode")[0]
+        var rating = feedback.getElementsByTagName("GUF_RatingCode")[0]
           .getAttribute("codeListValue");
       } catch(err) {
-        rating = "No rating available"
+        var rating = ""
       };
-    }
+    };
+    if (rating.length == 0) {
+      rating = "No rating available"
+    };
 
     try {
       var comment = feedback.getElementsByTagName("guf\:comment")[0]
         .getElementsByTagName("gco\:CharacterString")[0].textContent;
     } catch(err) {
-      var comment = ""
-    };
-
-    if (comment.length == 0) {
       try {
         comment = feedback.getElementsByTagName("comment")[0]
           .getElementsByTagName("CharacterString")[0].textContent;
       } catch(err) {
-        comment = "No comment available"
+        var comment = ""
       };
+    };
+    if (comment.length == 0) {
+      comment = "No comment available"
     };
 
     try {
-      var motivation = feedback
-        .getElementsByTagName("guf\:GUF_MotivationCode")[0]
+      var motivation = feedback.getElementsByTagName("guf\:GUF_MotivationCode")[0]
         .getAttribute("codeListValue");
     } catch(err) {
-      var motivation = "";
-    };
-
-    if (motivation.length == 0) {
       try {
-        motivation = feedback
-          .getElementsByTagName("GUF_MotivationCode")[0]
+        var motivation = feedback.getElementsByTagName("GUF_MotivationCode")[0]
           .getAttribute("codeListValue");
       } catch(err) {
-        motivation = "No motivation available";
+        var motivation = "";
       };
-    }
+    };
+    if (motivation.length == 0) {
+      motivation = "No motivation available";
+    };
+
+ //   try {
+ //     var motivation = feedback
+ //       .getElementsByTagName("guf\:GUF_MotivationCode")[0]
+ //       .getAttribute("codeListValue");
+ //   } catch(err) {
+ //     var motivation = "";
+ //   };
+
+//    if (motivation.length == 0) {
+//      try {
+ //       motivation = feedback
+  //        .getElementsByTagName("GUF_MotivationCode")[0]
+   //       .getAttribute("codeListValue");
+//      } catch(err) {
+  //      motivation = "No motivation available";
+  //    };
+  //  }
 
     var entryDict = {
       "commentId": commentId,

--- a/ckanext/nextgeoss/public/communityfeedback.js
+++ b/ckanext/nextgeoss/public/communityfeedback.js
@@ -202,24 +202,6 @@ function communityFeedback(catalogueID, catalogueNamespace, title)
       motivation = "No motivation available";
     };
 
- //   try {
- //     var motivation = feedback
- //       .getElementsByTagName("guf\:GUF_MotivationCode")[0]
- //       .getAttribute("codeListValue");
- //   } catch(err) {
- //     var motivation = "";
- //   };
-
-//    if (motivation.length == 0) {
-//      try {
- //       motivation = feedback
-  //        .getElementsByTagName("GUF_MotivationCode")[0]
-   //       .getAttribute("codeListValue");
-//      } catch(err) {
-  //      motivation = "No motivation available";
-  //    };
-  //  }
-
     var entryDict = {
       "commentId": commentId,
       "updated": updated,

--- a/ckanext/nextgeoss/public/communityfeedback.js
+++ b/ckanext/nextgeoss/public/communityfeedback.js
@@ -7,13 +7,13 @@ function communityFeedback(catalogueID, catalogueNamespace, title)
 
   this.getFeedbackUrl = function() {
     // Get the URL for feedback feed.
-    var url = 'http://www.opengis.uab.cat/cgi-bin/nimmbus/nimmbus.cgi?SERVICE=WPS&REQUEST=EXECUTE&IDENTIFIER=NB_RESOURCE:ENUMERATE&LANGUAGE=eng&STARTINDEX=1&COUNT=100&FORMAT=text/xml&TYPE=FEEDBACK&TRG_TYPE_1=CITATION&TRG_FLD_1=CODE&TRG_VL_1='+this.catalogueID+'&TRG_OPR_1=EQ&TRG_NXS_1=AND&TRG_TYPE_2=CITATION&TRG_FLD_2=NAMESPACE&TRG_VL_2='+this.catalogueNamespace+'&TRG_OPR_2=EQ'
+    var url = 'https://www.opengis.uab.cat/cgi-bin/nimmbus/nimmbus.cgi?SERVICE=WPS&REQUEST=EXECUTE&IDENTIFIER=NB_RESOURCE:ENUMERATE&LANGUAGE=eng&STARTINDEX=1&COUNT=100&FORMAT=text/xml&TYPE=FEEDBACK&TRG_TYPE_1=CITATION&TRG_FLD_1=CODE&TRG_VL_1='+this.catalogueID+'&TRG_OPR_1=EQ&TRG_NXS_1=AND&TRG_TYPE_2=CITATION&TRG_FLD_2=NAMESPACE&TRG_VL_2='+this.catalogueNamespace+'&TRG_OPR_2=EQ'
     return url
   };
 
   this.getAddFeedbackUrl = function() {
     // Get the URL for adding feedback.
-    var url = 'http://www.opengis.uab.cat/nimmbus/index.htm?target_title='+this.title+'&target_code='+this.catalogueID+'&target_codespace='+this.catalogueNamespace+'&page=ADDFEEDBACK&share_borrower_1=Anonymous'
+    var url = 'https://www.opengis.uab.cat/nimmbus/index.htm?target_title='+this.title+'&target_code='+this.catalogueID+'&target_codespace='+this.catalogueNamespace+'&page=ADDFEEDBACK&share_borrower_1=Anonymous'
     return url
   };
 

--- a/ckanext/nextgeoss/public/communityfeedback.js
+++ b/ckanext/nextgeoss/public/communityfeedback.js
@@ -111,22 +111,6 @@ function communityFeedback(catalogueID, catalogueNamespace, title)
     // Parse the feedback and insert fallback values if certain
     // data is missing.
     try {
-      var title = feedback.getElementsByTagName("mcc\:description")[0]
-        .getElementsByTagName("gco\:CharacterString")[0].textContent;
-    } catch(err) {
-      var title = "";
-    };
-
-    if (title.length == 0) {
-      try {
-        title = feedback.getElementsByTagName("description")[0]
-          .getElementsByTagName("CharacterString")[0].textContent;
-      } catch(err) {
-        title = "Untitled";
-      };
-    };
-
-    try {
       var updated = feedback.getElementsByTagName("cit\:date")[0]
         .getElementsByTagName("gco\:DateTime")[0].textContent;
     } catch(err) {
@@ -227,7 +211,6 @@ function communityFeedback(catalogueID, catalogueNamespace, title)
     }
 
     var entryDict = {
-      "title": title,
       "commentId": commentId,
       "updated": updated,
       "author": author,


### PR DESCRIPTION
The NiMMbus server now supports HTTPS (and provides HTTPS urls in the feeds it supplies), so we can use HTTPS across the board now.