### PR TITLE
Get disclaimer text from settings

### DIFF
--- a/ckanext/nextgeoss/helpers.py
+++ b/ckanext/nextgeoss/helpers.py
@@ -37,3 +37,16 @@ def get_add_feedback_url(dataset):
         target_codespace=config.get('ckan.site_url'))
 
     return feedback_url
+
+
+def get_bug_disclaimer():
+    """
+    Get the text of the disclaimer that will appear beneath the
+    issue tracker banner while waiting for it to load (or instead
+    of the banner in case the script does not load at all).
+    """
+    setting = 'ckanext.nextgeoss.bug_disclaimer'
+    default = 'This is a testing portal. Click here to submit a bug.'
+    disclaimer = config.get(setting, default)
+
+    return disclaimer

--- a/ckanext/nextgeoss/plugin.py
+++ b/ckanext/nextgeoss/plugin.py
@@ -20,6 +20,7 @@ class NextgeossPlugin(plugins.SingletonPlugin):
         toolkit.add_template_directory(config_, 'templates')
         toolkit.add_public_directory(config_, 'public')
         toolkit.add_resource('fanstatic', 'nextgeoss')
+        toolkit.add_resource('vendor', '')
 
     # ITemplateHelpers
 
@@ -28,7 +29,8 @@ class NextgeossPlugin(plugins.SingletonPlugin):
             'nextgeoss_get_org_title': helpers.get_org_title,
             'nextgeoss_get_org_logo': helpers.get_org_logo,
             'nextgeoss_get_jira_script': helpers.get_jira_script,
-            'nextgeoss_get_add_feedback_url': helpers.get_add_feedback_url
+            'nextgeoss_get_add_feedback_url': helpers.get_add_feedback_url,
+            'nextgeoss_get_bug_disclaimer': helpers.get_bug_disclaimer
         }
 
     # IRoutes

--- a/ckanext/nextgeoss/templates/header.html
+++ b/ckanext/nextgeoss/templates/header.html
@@ -1,6 +1,6 @@
 {% block header_wrapper %}
   <div class="disclaimer">
-    <p>Alpha Version. Report a bug or request a feature.</p>
+    <p>{{ h.nextgeoss_get_bug_disclaimer() }}</p>
   </div>
 
   <header class="navbar navbar-static-top masthead">


### PR DESCRIPTION
Get the disclaimer text from the settings so that we can two different versions of the text, one for staging and one for production.