### PR TITLE
Prevent layout change during spatial search

### DIFF
--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -754,6 +754,12 @@ h4.text-left.description {
   margin-top: 68px;
 }
 
+@media (max-width: 500px) {
+  .dataset-map-expanded #green {
+  margin-top: 36px;
+  }
+}
+
 #dataset-map .module-heading {
   border-color: #D7EDEC;
   border-radius: 0px;

--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -751,7 +751,7 @@ h4.text-left.description {
 }
 
 .dataset-map-expanded #green {
-  margin-top: 52px;
+  margin-top: 68px;
 }
 
 #dataset-map .module-heading {


### PR DESCRIPTION
Adding the map credits changed the ratios for spacing some of the other elements when the Cancel and Apply button appear after beginning a spatial search. The lower part of the search layout will jump up on desktop and down on mobile. These changes keep the spacing between the map and the search bar constant.