### PR TITLE
[#26] Revise/remove metadata when rendering template

### DIFF
--- a/ckanext/nextgeoss/helpers.py
+++ b/ckanext/nextgeoss/helpers.py
@@ -37,3 +37,41 @@ def get_add_feedback_url(dataset):
         target_codespace=config.get('ckan.site_url'))
 
     return feedback_url
+
+
+def get_extra_names():
+    """
+    Return a dictionary of new names for use with
+    the subs parameter of h.sorted_extras. We may
+    want to grab these names from the config in
+    the future.
+    """
+    new_names = {
+        'CloudCoverage': 'Cloud Coverage',
+        'FamilyName': 'Family Name',
+        'InstrumentFamilyName': 'Instrument Family Name',
+        'InstrumentMode': 'Instrument Mode',
+        'InstrumentName': 'Instrument Name',
+        'OrbitDirection': 'Orbit Direction',
+        'ProductType': 'Product Type',
+        'StartTime': 'Start Time',
+        'StopTime': 'Stop Time',
+        'spatial': 'Spatial Extent',
+        'uuid': 'Identifier'
+    }
+
+    return new_names
+
+
+def get_extras_to_exclude():
+    """
+    Return a list of extras to exclude from
+    rendered templates using the exclude parameter
+    of h.sorted_extras. We may want to grab this
+    list from the config in the future.
+    """
+    extras_to_exclude = [
+        'thumbnail'
+    ]
+
+    return extras_to_exclude

--- a/ckanext/nextgeoss/plugin.py
+++ b/ckanext/nextgeoss/plugin.py
@@ -28,7 +28,9 @@ class NextgeossPlugin(plugins.SingletonPlugin):
             'nextgeoss_get_org_title': helpers.get_org_title,
             'nextgeoss_get_org_logo': helpers.get_org_logo,
             'nextgeoss_get_jira_script': helpers.get_jira_script,
-            'nextgeoss_get_add_feedback_url': helpers.get_add_feedback_url
+            'nextgeoss_get_add_feedback_url': helpers.get_add_feedback_url,
+            'ng_extra_names': helpers.get_extra_names,
+            'ng_extras_to_exclude': helpers.get_extras_to_exclude
         }
 
     # IRoutes

--- a/ckanext/nextgeoss/templates/package/snippets/additional_info.html
+++ b/ckanext/nextgeoss/templates/package/snippets/additional_info.html
@@ -64,7 +64,7 @@
         {% endif %}
 
       {% block extras scoped %}
-        {% for extra in h.sorted_extras(pkg_dict.extras) %}
+        {% for extra in h.sorted_extras(pkg_dict.extras, subs=h.ng_extra_names(), exclude=h.ng_extras_to_exclude()) %}
           {% set key, value = extra %}
           <tr rel="dc:relation" resource="_:extra{{ i }}">
             <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key) }}</th>

--- a/ckanext/nextgeoss/templates/package/snippets/additional_info.html
+++ b/ckanext/nextgeoss/templates/package/snippets/additional_info.html
@@ -47,7 +47,7 @@
 
         {% if pkg_dict.metadata_modified %}
           <tr>
-            <th scope="row" class="dataset-label">{{ _("Last Updated") }}</th>
+            <th scope="row" class="dataset-label">{{ _("Last Updated on Data Hub") }}</th>
             <td class="dataset-details">
                 {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=pkg_dict.metadata_modified %}
             </td>
@@ -55,7 +55,7 @@
         {% endif %}
         {% if pkg_dict.metadata_created %}
           <tr>
-            <th scope="row" class="dataset-label">{{ _("Created") }}</th>
+            <th scope="row" class="dataset-label">{{ _("Record Created on Data Hub") }}</th>
 
             <td class="dataset-details">
                 {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=pkg_dict.metadata_created %}

--- a/ckanext/nextgeoss/templates/package/snippets/additional_info.html
+++ b/ckanext/nextgeoss/templates/package/snippets/additional_info.html
@@ -45,12 +45,6 @@
           </tr>
         {% endif %}
 
-        {% if h.check_access('package_update',{'id':pkg_dict.id}) %}
-          <tr>
-            <th scope="row" class="dataset-label">{{ _("State") }}</th>
-            <td class="dataset-details">{{ _(pkg_dict.state) }}</td>
-          </tr>
-        {% endif %}
         {% if pkg_dict.metadata_modified %}
           <tr>
             <th scope="row" class="dataset-label">{{ _("Last Updated") }}</th>


### PR DESCRIPTION
  - Rename extras with their correct names
- Remove extras that should not be displayed
- Revise the names of CKAN-specific metadata so that users understand that it does not apply to the original dataset

Closes #26 