### PR TITLE
[#28, #29] Fix resource list

### DIFF
--- a/ckanext/nextgeoss/templates/package/snippets/resource_item.html
+++ b/ckanext/nextgeoss/templates/package/snippets/resource_item.html
@@ -34,7 +34,6 @@
         <a href="{{ res.url }}"  class="btn btn-primary"><i class="fa fa-download"></i> {{ _('Download') }}</a>
       </div>
     </div>
-    </div>
   </div>
 </div>
 


### PR DESCRIPTION
Removes an extra `</div>` that breaks the design.

Closes #28 and fixes #29. 