### PR TITLE
Three mobile fixes

### DIFF
--- a/ckanext/nextgeoss/public/mobiletables.js
+++ b/ckanext/nextgeoss/public/mobiletables.js
@@ -1,0 +1,14 @@
+function mobileTable()
+// Reformat additional info/metadata tables for mobile displays.
+// The relevat CSS is in nextgeoss.css.
+{
+  $(document).ready(
+    function () { 
+      if ($(window).width() < 768) {
+        $( "table" ).toggleClass( "mobile-table" );
+        $('table').find('td').unwrap().wrap($('<tr/>')
+            );
+      }
+    }
+  );
+};

--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -1218,3 +1218,9 @@ button.btn.btn-navbar {
   padding-top: 6px;
   padding-bottom: 6px;
 }
+
+@media (max-width: 412px) {
+  .resource-box-buttons a {
+    font-size: 14px;
+  }
+}

--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -1224,3 +1224,22 @@ button.btn.btn-navbar {
     font-size: 14px;
   }
 }
+
+table.table.table-bordered.table-dataset.mobile-table {
+  border-collapse: collapse;
+}
+
+table.mobile-table th.dataset-label {
+  text-align: left;
+  border-bottom: none;
+  padding-bottom: 4px;
+  padding-left: 10px;
+  padding-right: 10px !important;
+}
+
+table.mobile-table td.dataset-details {
+  border-top: none;
+  padding-top: 4px;
+  padding-left: 10px !important;
+  padding-right: 10px;
+}

--- a/ckanext/nextgeoss/templates/base.html
+++ b/ckanext/nextgeoss/templates/base.html
@@ -14,6 +14,7 @@
   <script src="/jquery.min.js" type="text/javascript"></script>
   <script src="/dropdown.js" type="text/javascript"></script>
   <script src="/communityfeedback.js" type="text/javascript"></script>
+  <script src="/mobiletables.js" type="text/javascript"></script>
 
   <!--     Fonts and icons     -->
   <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Raleway:300,400,500,700" />

--- a/ckanext/nextgeoss/templates/header.html
+++ b/ckanext/nextgeoss/templates/header.html
@@ -12,9 +12,9 @@
 
     <div class="container">
       <button data-target=".nav-collapse" data-toggle="collapse" class="btn btn-navbar" type="button">
-        <span class="fa fa-bar"></span>
-        <span class="fa fa-bar"></span>
-        <span class="fa fa-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
       </button>
 
       {# The .header-image class hides the main text and uses image replacement for the title #}

--- a/ckanext/nextgeoss/templates/package/read.html
+++ b/ckanext/nextgeoss/templates/package/read.html
@@ -65,4 +65,7 @@
 
     {% snippet "snippets/social_inline.html" %}
   </div>
+
+  <script>mobileTable();</script>
+
 {% endblock %}

--- a/ckanext/nextgeoss/templates/package/resource_read.html
+++ b/ckanext/nextgeoss/templates/package/resource_read.html
@@ -130,4 +130,7 @@
 
   {% snippet "snippets/social_inline.html" %}
   </div>
+
+  <script>mobileTable();</script>
+
 {% endblock %}

--- a/ckanext/nextgeoss/templates/package/snippets/resource_item.html
+++ b/ckanext/nextgeoss/templates/package/snippets/resource_item.html
@@ -30,7 +30,7 @@
         {% else %}
           {% set button_label = _('More info') %}
         {% endif %}
-        <a a href="{{ url }}" class="btn btn-primary btn-left"><i class="fa fa-info-circle"></i> {{ button_label }}</a>
+        <a href="{{ url }}" class="btn btn-primary btn-left"><i class="fa fa-info-circle"></i> {{ button_label }}</a>
         <a href="{{ res.url }}"  class="btn btn-primary"><i class="fa fa-download"></i> {{ _('Download') }}</a>
       </div>
     </div>


### PR DESCRIPTION
- Restores the bars on the mobile menu and closes #35 
- Prevents resource buttons from overlapping and closes #36 
- Reformats additional info/metadata tables on mobile displays and closes #34 (if JS is blocked, the design falls back to the normal table formatting)

(We may want to work on the general styling of the metadata later, but we can tackle that as part of a general metadata presentation ticket.)