### PR TITLE
Display correct number of datasets on homepage 

### DIFF
--- a/ckanext/nextgeoss/helpers.py
+++ b/ckanext/nextgeoss/helpers.py
@@ -1,4 +1,5 @@
 from ckan.common import config
+import ckan.logic as logic
 import ast
 
 
@@ -304,3 +305,13 @@ def get_pkg_dict_dataset_extra(pkg_dict, key, default=None):
                 return value
 
     return default
+
+
+def nextgeoss_get_site_statistics():
+    stats = {}
+    stats['dataset_count'] = logic.get_action('package_search')(
+        {'include_private': True}, {"rows": 1})['count']
+    stats['group_count'] = len(logic.get_action('group_list')({}, {}))
+    stats['organization_count'] = len(
+        logic.get_action('organization_list')({}, {}))
+    return stats

--- a/ckanext/nextgeoss/plugin.py
+++ b/ckanext/nextgeoss/plugin.py
@@ -40,7 +40,8 @@ class NextgeossPlugin(plugins.SingletonPlugin):
              'ng_get_dataset_thumbnail_path': helpers.get_dataset_thumbnail_path,  # noqa: E501
              'ng_get_from_extras': helpers.get_from_extras,
              'ng_get_source_namespace': helpers.get_source_namespace,
-             'get_pkg_dict_dataset_extra': helpers.get_pkg_dict_dataset_extra
+             'get_pkg_dict_dataset_extra': helpers.get_pkg_dict_dataset_extra,
+             'nextgeoss_get_site_statistics': helpers.nextgeoss_get_site_statistics
         }
 
     # IRoutes

--- a/ckanext/nextgeoss/templates/home/snippets/search.html
+++ b/ckanext/nextgeoss/templates/home/snippets/search.html
@@ -2,7 +2,7 @@
 {% set placeholder = _('Try "sea level portugal"') %}
 
 <form class="search-form" method="get" action="{% url_for controller='package', action='search' %}">
-  {% set count = h.get_site_statistics().dataset_count %}
+  {% set count = h.nextgeoss_get_site_statistics().dataset_count %}
   {% if count %}
       {% set search_message = ungettext('Search {number} Earth observation dataset', 'Search {number} Earth observation datasets', count) %}
   {% else %}


### PR DESCRIPTION
The homepage was displaying the number of public datasets on the portal, and if you had a sysadmin account the number of datasets on the homepage and the datasets page was not the same.
This pull request fixes this issue