### PR TITLE
Fix reindexing for noa_expiration_date

### DIFF
--- a/ckanext/nextgeoss/plugin.py
+++ b/ckanext/nextgeoss/plugin.py
@@ -189,6 +189,11 @@ class NextgeossPlugin(plugins.SingletonPlugin):
 
         # Handle spatial indexing here since the string extras break
         # the spatial extension.
+        noa = pkg_dict.get("noa_expiration_date", None)
+
+        if noa is not None:
+          pkg_dict.pop("noa_expiration_date", None)
+
         geometry = pkg_dict.get("spatial", None)
         if geometry:
             geometry = json.loads(geometry)


### PR DESCRIPTION
The format of noa_expiration_date is Invalid Date String in SOLR.
This fix removes the noa_expiration_date from the fields that are indexed by SOLR