### PR TITLE
Handle string extras conversions in one place

### DIFF
--- a/ckanext/nextgeoss/helpers.py
+++ b/ckanext/nextgeoss/helpers.py
@@ -1,6 +1,5 @@
 from ckan.common import config
 import ckan.logic as logic
-import ckan.lib.helpers as helpers
 import ast
 
 
@@ -51,14 +50,12 @@ def topic_resources(extras):
         k, v = extra[0], extra[1]
         if 'resource_' in k and 'Social Media' not in v:
             no_resources = no_resources - 1
-            import ast
             values = ast.literal_eval(extra[1])
             resources.append({'key': extra[0], 'value': str(values)})
     return resources
 
 
 def get_value(resources, key):
-    import ast
     resources_tmp = ast.literal_eval(resources)
     value = ''
 
@@ -81,44 +78,6 @@ def get_pilot_extras(extras):
             print pilot_extras
     print type(pilot_extras)
     return pilot_extras
-
-
-def harvest_sorted_extras(package_extras, auto_clean=False, subs=None,
-                          exclude=None):
-    ''' Used for outputting package extras
-    :param package_extras: the package extras
-    :type package_extras: dict
-    :param auto_clean: If true capitalize and replace -_ with spaces
-    :type auto_clean: bool
-    :param subs: substitutes to use instead of given keys
-    :type subs: dict {'key': 'replacement'}
-    :param exclude: keys to exclude
-    :type exclude: list of strings
-    '''
-
-    # If exclude is not supplied use values defined in the config
-    if not exclude:
-        exclude = config.get('package_hide_extras', [])
-    output = []
-
-    for extra in sorted(package_extras, key=lambda x: x['key']):
-        if extra.get('state') == 'deleted':
-            continue
-        extras_tmp = ast.literal_eval(extra['value'])
-
-        for ext in extras_tmp:
-            k, v = ext['key'], ext['value']
-            if k in exclude:
-                continue
-            if subs and k in subs:
-                k = subs[k]
-            elif auto_clean:
-                k = k.replace('_', ' ').replace('-', ' ').title()
-            if isinstance(v, (list, tuple)):
-                v = ", ".join(map(unicode, v))
-            output.append((k, v))
-
-    return output
 
 
 def get_extra_names():
@@ -263,17 +222,6 @@ def get_dataset_thumbnail_path(dataset):
     return '/base/images/placeholder-image.png'
 
 
-def get_from_extras(data_dict, key, alt_value=None):
-    """Return the value of a key in the extras list, or an alternate value."""
-    extras = data_dict.get('extras')
-
-    for extra in extras:
-        if extra['key'] == key:
-            return extra['value']
-
-    return alt_value
-
-
 def get_source_namespace(data_dict):
     """Return the source namespace for a product."""
     source = data_dict['organization']['title']
@@ -284,32 +232,6 @@ def get_source_namespace(data_dict):
     }
 
     return namespaces.get(source, None)
-
-
-def get_pkg_dict_dataset_extra(pkg_dict, key, default=None):
-    '''Returns the value for the dataset extra with the provided key.
-
-    If the key is not found, it returns a default value, which is None by
-    default.
-
-    :param pkg_dict: dictized dataset
-    :key: extra key to lookup
-    :default: default value returned if not found
-    '''
-
-    extras = pkg_dict['extras'] if 'extras' in pkg_dict else []
-
-    if extras[0]['key'] == 'dataset_extra':
-        for extra in extras:
-            extras_tmp = ast.literal_eval(extra['value'])
-
-            for ext in extras_tmp:
-                if ext['key'] == key:
-                    value = ext['value']
-                    return value
-    else:
-        default = helpers.get_pkg_dict_extra(pkg_dict, key, default=None)
-        return default
 
 
 def nextgeoss_get_site_statistics():

--- a/ckanext/nextgeoss/plugin.py
+++ b/ckanext/nextgeoss/plugin.py
@@ -41,14 +41,11 @@ class NextgeossPlugin(plugins.SingletonPlugin):
              'nextgeoss_get_topic_resources': helpers.topic_resources,
              'nextgeoss_get_value': helpers.get_value,
              'nextgeoss_get_pilot_extras': helpers.get_pilot_extras,
-             'harvest_sorted_extras': helpers.harvest_sorted_extras,
              'ng_extra_names': helpers.get_extra_names,
              'ng_extras_to_exclude': helpers.get_extras_to_exclude,
              'ng_get_dataset_thumbnail_path': helpers.get_dataset_thumbnail_path,  # noqa: E501
-             'ng_get_from_extras': helpers.get_from_extras,
              'ng_get_source_namespace': helpers.get_source_namespace,
-             'get_pkg_dict_dataset_extra': helpers.get_pkg_dict_dataset_extra,
-             'nextgeoss_get_site_statistics': helpers.nextgeoss_get_site_statistics
+             'nextgeoss_get_site_statistics': helpers.nextgeoss_get_site_statistics  # noqa: E501
         }
 
     # IRoutes
@@ -192,7 +189,7 @@ class NextgeossPlugin(plugins.SingletonPlugin):
         noa = pkg_dict.get("noa_expiration_date", None)
 
         if noa is not None:
-          pkg_dict.pop("noa_expiration_date", None)
+            pkg_dict.pop("noa_expiration_date", None)
 
         geometry = pkg_dict.get("spatial", None)
         if geometry:
@@ -229,11 +226,38 @@ class NextgeossPlugin(plugins.SingletonPlugin):
 
         return pkg_dict
 
+    def after_show(self, context, pkg_dict):
+        """
+        Convert extras saved as a string to a normal extras list.
+
+        Note: This is only necessary if datasets have been indexed _without_
+        converting the string extras to a normal extras list. If _all_ the
+        datasets are correctly indexed (i.e., the conversion was carried out in
+        the before_index stage) then this method is not necessary.
+        """
+        return string_extras_to_extras_list(pkg_dict)
+
+    def after_search(self, search_results, search_params):
+        """
+        Convert extras saved as a string to a normal extras list.
+
+        Note: This is only necessary if datasets have been indexed _without_
+        converting the string extras to a normal extras list. If _all_ the
+        datasets are correctly indexed (i.e., the conversion was carried out in
+        the before_index stage) then this method is not necessary.
+        """
+        search_results["results"] = [string_extras_to_extras_list(result)
+                                     for result in search_results["results"]]
+
+        return search_results
+
 
 # Make the portal private for the beta
 # Yes, this is bad.
 # Locking down the beta is worse.
 # When the beta is over, we can just delete this section.
+
+
 def private(self, action, **env):
     if "oauth2" in config.get("ckan.plugins"):
         url = h.current_url()
@@ -280,3 +304,13 @@ def convert_dataset_extra(dataset_extra_string):
     extras = ast.literal_eval(dataset_extra_string)
 
     return [(extra["key"], extra["value"]) for extra in extras]
+
+
+def string_extras_to_extras_list(pkg_dict):
+    """Convert extras saved as a string to a normal extras list."""
+    extras = pkg_dict.get("extras")
+
+    if extras and extras[0]["key"] == "dataset_extra":
+        pkg_dict["extras"] = ast.literal_eval(extras[0]["value"])
+
+    return pkg_dict

--- a/ckanext/nextgeoss/templates/package/read.html
+++ b/ckanext/nextgeoss/templates/package/read.html
@@ -47,7 +47,7 @@
 
     {% endblock %}
 
-    {% set dataset_extent = h.get_pkg_dict_dataset_extra(c.pkg_dict, 'spatial', '') %}
+    {% set dataset_extent = h.get_pkg_dict_extra(c.pkg_dict, 'spatial', '') %}
 
     {% if dataset_extent %}
       {% snippet "spatial/snippets/dataset_map_big.html", extent=dataset_extent %}

--- a/ckanext/nextgeoss/templates/package/snippets/additional_info.html
+++ b/ckanext/nextgeoss/templates/package/snippets/additional_info.html
@@ -78,33 +78,13 @@
         'InstrumentName': 'Instrument Name',
         'OrbitDirection': 'Orbit Direction', 'StartTime': 'Start Time',
         'StopTime': 'Stop Time'}%}
-        {% if pkg_dict.extras %}
-          {% if pkg_dict.extras[0]['key'] == 'dataset_extra' %}
-            {% for extra in h.harvest_sorted_extras(pkg_dict.extras, subs=subs, exclude=exclude) %}
-              {% set key, value = extra %}
-              <tr rel="dc:relation" resource="_:extra{{ i }}">
-                <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key) }}</th>
-                <td class="dataset-details" property="rdf:value">{{ value }}</td>
-              </tr>
-            {% endfor %}
-          {% else %}
-            {% for extra in h.sorted_extras(pkg_dict.extras, subs=subs, exclude=exclude) %}
-              {% set key, value = extra %}
-              <tr rel="dc:relation" resource="_:extra{{ i }}">
-                <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key) }}</th>
-                <td class="dataset-details" property="rdf:value">{{ value }}</td>
-              </tr>
-            {% endfor %}
-        {% endif %}
-        {% else %}
-          {% for extra in h.harvest_sorted_extras(pkg_dict.extras, subs=subs, exclude=exclude) %}
-            {% set key, value = extra %}
-              <tr rel="dc:relation" resource="_:extra{{ i }}">
-                <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key) }}</th>
-                <td class="dataset-details" property="rdf:value">{{ value }}</td>
-              </tr>
-          {% endfor %}
-        {% endif %}
+        {% for extra in h.sorted_extras(pkg_dict.extras, subs=subs, exclude=exclude) %}
+          {% set key, value = extra %}
+            <tr rel="dc:relation" resource="_:extra{{ i }}">
+              <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key) }}</th>
+              <td class="dataset-details" property="rdf:value">{{ value }}</td>
+            </tr>
+        {% endfor %}
       {% endblock %}
 
       {% endblock %}

--- a/ckanext/nextgeoss/templates/package/snippets/community_feedback.html
+++ b/ckanext/nextgeoss/templates/package/snippets/community_feedback.html
@@ -6,7 +6,7 @@
   This two-step processed is only used to avoid creating another helper function that would just be removed later -->
   {% set catalogue_url = h.get_site_protocol_and_host() %}
   {% set source_namespace = h.ng_get_source_namespace(pkg) or  '%s://%s'|format(catalogue_url[0], catalogue_url[1])%}
-  {% set source_id = h.ng_get_from_extras(pkg, 'identifier') or h.ng_get_from_extras(pkg, 'uuid') or pkg['id'] %}
+  {% set source_id = h.get_pkg_dict_extra(pkg, 'identifier') or h.get_pkg_dict_extra(pkg, 'uuid', '') or pkg['id'] %}
   {% set title = pkg.get('title', pkg['name']) %}
 
   <!-- Display the community feedback if available -->


### PR DESCRIPTION
Handle all the string extras conversions in the IPackageController hook. The extras are converted from a string to a list of dicts by package_show and package_search and before being indexed, so the package dicts that templates, etc. receive have normal extras and there's no need to add helpers or write special functions to process the string extras in each extension, template, etc.

Note: The after_show and after_search hooks are is only necessary if datasets have been indexed _without_ converting the string extras to a normal extras list. If _all_ the datasets are correctly indexed (i.e., the conversion was carried out in the before_index stage) then these hooks are unnecessary because package_show and package_search rely on the indexed extras. If they've been indexed normally, then _show and _search will return normal pkg_dicts with normal extras lists and there's no need to perform any conversions. If there are still some datasets that are not correctly indexed, then the conversions in after_show and after_search are still necessary.