### PR TITLE
Split content on OpenSearch page in panels

### DIFF
--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -98,6 +98,16 @@ body,.masthead, [role="main"], .main {
   outline: 0;
 }
 
+a {
+  word-break: break-word;
+}
+
+code {
+  word-break: break-word;
+  background-color: #f8f8f8;
+  color: #2f4f4f;
+}
+
 a:focus, a:active,
 button:active, button:focus, button:hover,
 button::-moz-focus-inner,

--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -899,6 +899,7 @@ section.dataset-map-section {
 
 article.module {
   margin-top: 50px !important;
+  font-size: 1.15em;
 }
 
 .span9>article.module {
@@ -1329,7 +1330,7 @@ table.mobile-table td.dataset-details {
     margin-right: 0px;
     margin-left: 0px;
   }
-
+}
 .search-padding {
  padding-top: 20px;
 }
@@ -1450,4 +1451,22 @@ table.mobile-table td.dataset-details {
 @keyframes fadeIn {
     0% { opacity:0; }
     100% { opacity:100%; }
+}
+
+.opensearch-info-panel > .panel-group > .panel-info > .panel-heading {
+    background: #D7EDEC;
+    color: #333;
+    font-size: 1.22em;
+}
+
+.opensearch-info-panel >.panel-group > .panel-info > .panel-heading h4 {
+    font-weight: bolder;
+}
+
+.opensearch-info-panel > .panel-group > .panel-info {
+    border-color: #D7EDEC;
+}
+
+.opensearch-info-panel > .panel-group {
+    margin-top: 1.5em;
 }

--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -1463,20 +1463,20 @@ table.mobile-table td.dataset-details {
     100% { opacity:100%; }
 }
 
-.opensearch-info-panel > .panel-group > .panel-info > .panel-heading {
-    background: #D7EDEC;
-    color: #333;
-    font-size: 1.22em;
+.opensearch-info-panel .panel-heading {
+    background: #D7EDEC !important;
+    color: #333 !important;
+    font-size: 1.22em !important;
 }
 
-.opensearch-info-panel >.panel-group > .panel-info > .panel-heading h4 {
-    font-weight: bolder;
+.opensearch-info-panel .panel-heading h4 {
+    font-weight: bolder !important;
 }
 
-.opensearch-info-panel > .panel-group > .panel-info {
-    border-color: #D7EDEC;
+.opensearch-info-panel .panel-info {
+    border-color: #D7EDEC !important;
 }
 
-.opensearch-info-panel > .panel-group {
-    margin-top: 1.5em;
+.opensearch-info-panel .panel-group {
+    margin-top: 1.5em !important;
 }

--- a/ckanext/nextgeoss/templates/static/opensearch.html
+++ b/ckanext/nextgeoss/templates/static/opensearch.html
@@ -23,7 +23,7 @@
               </h4>
             </div>
             <div class="panel-body">
-                <p>The description documents are available at the following endpoint: https://catalogue.nextgeoss.eu/opensearch/description.xml?osdd={OpenSearch Description Document ID}. The osdd parameter is required. There is one description document for step one of two-step search (or "collection search") and each individual collection has its own description document. The search results of collection search include a link to the description document for each collection, so you only need the description document for collection search in order to begin using the OpenSearch interface. Your client will discover the relevant collection-level description documents for you as you search.</p>
+                <p>The description documents are available at the following endpoint: <code>https://catalogue.nextgeoss.eu/opensearch/description.xml?osdd={OpenSearch Description Document ID}</code>. The osdd parameter is required. There is one description document for step one of two-step search (or "collection search") and each individual collection has its own description document. The search results of collection search include a link to the description document for each collection, so you only need the description document for collection search in order to begin using the OpenSearch interface. Your client will discover the relevant collection-level description documents for you as you search.</p>
                 <p>Access the collection search description document here:
                 </br>
                 <a href="https://catalogue.nextgeoss.eu/opensearch/description.xml?osdd=collection">https://catalogue.nextgeoss.eu/opensearch/description.xml?osdd=collection</a>
@@ -37,7 +37,7 @@
               </h4>
             </div>
             <div class="panel-body">
-              <p>The search endpoints are located at https://catalogue.nextgeoss.eu/opensearch/collection_search.atom? (for step one or collection search) and https://catalogue.nextgeoss.eu/opensearch/search.atom? (for step two or product search/search within a given collection).</p>
+              <p>The search endpoints are located at <code>https://catalogue.nextgeoss.eu/opensearch/collection_search.atom?</code> (for step one or collection search) and <code>https://catalogue.nextgeoss.eu/opensearch/search.atom?</code> (for step two or product search/search within a given collection).</p>
               <p>The description documents instruct your client how to query each endpoint.</p>
             </div>
           </div>

--- a/ckanext/nextgeoss/templates/static/opensearch.html
+++ b/ckanext/nextgeoss/templates/static/opensearch.html
@@ -1,3 +1,4 @@
+
 {% extends "page.html" %}
 
 {% block subtitle %}{{ _('OpenSearch') }}{% endblock %}
@@ -13,66 +14,92 @@
 
       <p>The NextGEOSS data hub provides an OpenSearch interface supporting two-step search. Below you will find information about accessing the OpenSearch decription documents and the search endpoints, as well as a description of the available parameters. You will need a client to use OpenSearch. If you do not have an OpenSearch client or you are not a developer using the OpenSearch interface as the backend of your client or project, the OpenSearch interface is not for you. Please use the Web interface.
 
-      <h3>Accessing the Description Documents</h3>
+      <div class="opensearch-info-panel">
+        <div class="panel-group">
+          <div class="panel panel-default panel-info">
+            <div class="panel-heading">
+              <h4 class="panel-title">
+                Accessing the Description Documents
+              </h4>
+            </div>
+            <div class="panel-body">
+                <p>The description documents are available at the following endpoint: https://catalogue.nextgeoss.eu/opensearch/description.xml?osdd={OpenSearch Description Document ID}. The osdd parameter is required. There is one description document for step one of two-step search (or "collection search") and each individual collection has its own description document. The search results of collection search include a link to the description document for each collection, so you only need the description document for collection search in order to begin using the OpenSearch interface. Your client will discover the relevant collection-level description documents for you as you search.</p>
+                <p>Access the collection search description document here:
+                </br>
+                <a href="https://catalogue.nextgeoss.eu/opensearch/description.xml?osdd=collection">https://catalogue.nextgeoss.eu/opensearch/description.xml?osdd=collection</a>
+                </p>
+            </div>
+          </div>
+          <div class="panel panel-default panel-info">
+            <div class="panel-heading">
+              <h4 class="panel-title">
+                Accessing the Search Endpoints
+              </h4>
+            </div>
+            <div class="panel-body">
+              <p>The search endpoints are located at https://catalogue.nextgeoss.eu/opensearch/collection_search.atom? (for step one or collection search) and https://catalogue.nextgeoss.eu/opensearch/search.atom? (for step two or product search/search within a given collection).</p>
+              <p>The description documents instruct your client how to query each endpoint.</p>
+            </div>
+          </div>
+        </div>
+      </div>
 
-      <p>The description documents are available at the following endpoint: https://catalogue.nextgeoss.eu/opensearch/description.xml?osdd={OpenSearch Description Document ID}. The osdd parameter is required. There is one description document for step one of two-step search (or "collection search") and each individual collection has its own description document. The search results of collection search include a link to the description document for each collection, so you only need the description document for collection search in order to begin using the OpenSearch interface. Your client will discover the relevant collection-level description documents for you as you search.</p>
-
-      <p>Access the collection search description document here:
-      </br>
-      <a href="https://catalogue.nextgeoss.eu/opensearch/description.xml?osdd=collection">https://catalogue.nextgeoss.eu/opensearch/description.xml?osdd=collection</a>
-      </p>
-
-      <h3>Accessing the Search Endpoints</h3>
-
-      <p>The search endpoints are located at https://catalogue.nextgeoss.eu/opensearch/collection_search.atom? (for step one or collection search) and https://catalogue.nextgeoss.eu/opensearch/search.atom? (for step two or product search/search within a given collection).</p>
-
-      <p>The description documents instruct your client how to query each endpoint.</p>
-
-      <h3>Search Parameters</h3>
-
-      <p>Consult a description document and the related standards for details about the supported search parameters. The data hub supports the OpenSearch Geo and Time extensions.</p>
-
-      <p>By default, the following parameters are supported:</p>
-      <ul>
-        <li>opensearch:searchTerms</li>
-        <li>opensearch:searchTerms</li>
-        <li>opensearch:maxResults</li>
-        <li>opensearch:startPage</li>
-        <li>geo:box</li>
-        <li>geo:geometry</li>
-        <li>geo:uid</li>
-        <li>time:start</li>
-        <li>time:end</li>
-        <li>eo:modificationDate</li>
-      </ul>
-
-      <p>Additional parameters, including parameters that are specific to individual collections (like cloud coverage) will be added as the project progresses.</p>
-
-      <h3>Search Results</h3>
-
-      <p>The OpenSearch search results present a subset of the metadata available for each collection or product in the results. These defaults are chosen to comply with OGC OpenSearch best practices. For more details, consult OGC's documentation.</p>
-
-      <p>The metadata included in each entry in the results feed are:</p>
-
-      <ul>
-        <li>atom:title</li>
-        <li>atom:id</li>
-        <li>dc:identifier</li>
-        <li>atom:link rel="self"</li>
-        <li>atom:link rel="up"</li>
-        <li>dc:publisher</li>
-        <li>atom:published</li>
-        <li>atom:updated</li>
-        <li>atom:summary</li>
-        <li>dc:date</li>
-        <li>georss:polygon</li>
-        <li>atom:link rel="alternate"</li>
-        <li>atom:category</li>
-        <li>atom:link rel="enclosure"</li>
-      </ul>
-
-      <p>More detailed metadata will be added as the project progresses.</p>
-
+      <div class="opensearch-info-panel">
+        <div class="panel-group">
+          <div class="panel panel-default panel-info">
+            <div class="panel-heading">
+              <h4 class="panel-title">
+                Search Parameters
+              </h4>
+            </div>
+            <div class="panel-body">
+              <p>Consult a description document and the related standards for details about the supported search parameters. The data hub supports the OpenSearch Geo and Time extensions.</p>
+              <p>By default, the following parameters are supported:</p>
+              <ul>
+                <li>opensearch:searchTerms</li>
+                <li>opensearch:searchTerms</li>
+                <li>opensearch:maxResults</li>
+                <li>opensearch:startPage</li>
+                <li>geo:box</li>
+                <li>geo:geometry</li>
+                <li>geo:uid</li>
+                <li>time:start</li>
+                <li>time:end</li>
+                <li>eo:modificationDate</li>
+              </ul>
+              <p>Additional parameters, including parameters that are specific to individual collections (like cloud coverage) will be added as the project progresses.</p>
+            </div>
+          </div>
+          <div class="panel panel-default panel-info">
+            <div class="panel-heading">
+              <h4 class="panel-title">
+                Search Results
+              </h4>
+            </div>
+            <div class="panel-body">
+              <p>The OpenSearch search results present a subset of the metadata available for each collection or product in the results. These defaults are chosen to comply with OGC OpenSearch best practices. For more details, consult OGC's documentation.</p>
+              <p>The metadata included in each entry in the results feed are:</p>
+              <ul>
+                <li>atom:title</li>
+                <li>atom:id</li>
+                <li>dc:identifier</li>
+                <li>atom:link rel="self"</li>
+                <li>atom:link rel="up"</li>
+                <li>dc:publisher</li>
+                <li>atom:published</li>
+                <li>atom:updated</li>
+                <li>atom:summary</li>
+                <li>dc:date</li>
+                <li>georss:polygon</li>
+                <li>atom:link rel="alternate"</li>
+                <li>atom:category</li>
+                <li>atom:link rel="enclosure"</li>
+              </ul>
+              <p>More detailed metadata will be added as the project progresses.</p>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </article>
 {% endblock %}


### PR DESCRIPTION
This PR changes the layout of the OpenSearch page to make it a bit more easily digestible. Specifically, the 4 sections of the page were split into colorful panels and grouped according to their content. 

It now looks like this:

![image](https://user-images.githubusercontent.com/8862002/57148473-f9e68900-6dc9-11e9-9319-756b6c8f80d9.png)
