### PR TITLE
Add Read more for topic description

### DIFF
--- a/ckanext/nextgeoss/fanstatic/nextgeoss_read_more_paragraph.js
+++ b/ckanext/nextgeoss/fanstatic/nextgeoss_read_more_paragraph.js
@@ -1,0 +1,41 @@
+// Enable JavaScript's strict mode. Strict mode catches some common
+// programming errors and throws exceptions, prevents some unsafe actions from
+// being taken, and disables some confusing and bad JavaScript features.
+"use strict";
+
+ckan.module('nextgeoss_read_more_paragraph', function ($) {
+  return {
+    initialize: function () {
+      var showChar = 120;
+      var ellipsestext = "...";
+      var moretext = "Read More";
+      var lesstext = "Read Less";
+
+      var content = this.el.html();
+
+      if (content.length > showChar) {
+        var paragraphs = this.el.children('p');
+        var visibleParagraph = paragraphs[0];
+        var invisibleParagraphs = paragraphs.slice(1);
+
+        visibleParagraph.append(ellipsestext);
+        invisibleParagraphs.hide();
+
+        var moreLink = $('<a>', { class: 'morelink', text: moretext });
+        moreLink.insertAfter(visibleParagraph);
+      }
+
+
+      $(".morelink").click(function () {
+        invisibleParagraphs.toggle()
+        if($(this).hasClass("less")) {
+            $(this).removeClass("less");
+            $(this).html(moretext);
+        } else {
+            $(this).addClass("less");
+            $(this).html(lesstext);
+        }
+      });
+    }
+  };
+});

--- a/ckanext/nextgeoss/plugin.py
+++ b/ckanext/nextgeoss/plugin.py
@@ -30,6 +30,7 @@ class NextgeossPlugin(plugins.SingletonPlugin):
         toolkit.add_template_directory(config_, 'templates')
         toolkit.add_public_directory(config_, 'public')
         toolkit.add_resource('fanstatic', 'nextgeoss')
+        toolkit.add_resource('fanstatic', 'nextgeoss_read_more_paragraph')
 
     # ITemplateHelpers
 

--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -543,6 +543,10 @@ h5.dataset-detail-title {
   margin-top: 50px;
 }
 
+.dataset-notes > p {
+  margin-top: 10px !important;
+}
+
 #dataset-resources h3 {
   border-bottom: 1px solid #292929;
 }

--- a/ckanext/nextgeoss/templates/group/about.html
+++ b/ckanext/nextgeoss/templates/group/about.html
@@ -25,7 +25,7 @@
 
       {% block package_notes %}
         {% if c.group_dict.description %}
-          <div class="notes embedded-content dataset-notes">
+          <div data-module='nextgeoss_read_more_paragraph' class="notes embedded-content dataset-notes">
             {{ h.render_markdown(_(c.group_dict.description)) }}
           </div>
         {% endif %}

--- a/ckanext/nextgeoss/templates/page.html
+++ b/ckanext/nextgeoss/templates/page.html
@@ -8,6 +8,7 @@
 
   {%- block header %}
     {{ super() }}
+    {% resource 'nextgeoss_read_more_paragraph/nextgeoss_read_more_paragraph.js' %}
   {% endblock -%}
 
   {% block toolbar %}


### PR DESCRIPTION
This PR adds "Red more" functionality to topic description. That section normally contains quite a long markdown text. So in order to keep it relevant but also shorter we decided to show only the first paragraph by default and the remaining paragraphs under the "Read more" toggle.

It now looks like this:

![image](https://user-images.githubusercontent.com/8862002/57458663-05c2c700-7272-11e9-91f1-6a70aead519a.png)

And open 

![image](https://user-images.githubusercontent.com/8862002/57458684-0f4c2f00-7272-11e9-92f6-cd94d1903c93.png)

The space around "More information coming soon" is no doubt ugly but the styling belongs to the "more information" section and is outside the scope of this PR.  The time will come for it as well. 
