### PR TITLE
Fixes to dataset details

### DIFF
--- a/ckanext/nextgeoss/templates/package/activity.html
+++ b/ckanext/nextgeoss/templates/package/activity.html
@@ -48,6 +48,5 @@
   </div>
 {% endblock %}
 
-{% block single_column %}
-  {# prevents page template from inluding primary and secondary columns #}
+{% block secondary %}
 {% endblock %}

--- a/ckanext/nextgeoss/templates/package/activity.html
+++ b/ckanext/nextgeoss/templates/package/activity.html
@@ -35,7 +35,6 @@
         {% endblock %}
       </h1>
       <h5 class="dataset-detail-title">{{ _('Published by ') }} <a href="{{ org_link }}">{{ org_title }}</a></h5>
-      <h5 class="dataset-detail-title">{{ _('Licensed under ') }} {% snippet "snippets/license_inline.html", pkg_dict=pkg %}</h5>
     {% endblock %}
 
     <section class="additional-info">

--- a/ckanext/nextgeoss/templates/package/edit.html
+++ b/ckanext/nextgeoss/templates/package/edit.html
@@ -37,7 +37,6 @@
       {% endblock %}
     </h1>
     <h5 class="dataset-detail-title">{{ _('Published by ') }} <a href="{{ org_link }}">{{ org_title }}</a></h5>
-    <h5 class="dataset-detail-title">{{ _('Licensed under ') }} {% snippet "snippets/license_inline.html", pkg_dict=pkg %}</h5>
   {% endblock %}
 
   <section class="edit-dataset-info">

--- a/ckanext/nextgeoss/templates/package/edit.html
+++ b/ckanext/nextgeoss/templates/package/edit.html
@@ -51,6 +51,5 @@
 </div>
 {% endblock %}
 
-{% block single_column %}
-  {# prevents page template from inluding primary and secondary columns #}
+{% block secondary %}
 {% endblock %}

--- a/ckanext/nextgeoss/templates/package/group_list.html
+++ b/ckanext/nextgeoss/templates/package/group_list.html
@@ -38,7 +38,6 @@
         {% endblock %}
       </h1>
       <h5 class="dataset-detail-title">{{ _('Published by ') }} <a href="{{ org_link }}">{{ org_title }}</a></h5>
-      <h5 class="dataset-detail-title">{{ _('Licensed under ') }} {% snippet "snippets/license_inline.html", pkg_dict=pkg %}</h5>
     {% endblock %}
 
     <section class="additional-info">

--- a/ckanext/nextgeoss/templates/package/group_list.html
+++ b/ckanext/nextgeoss/templates/package/group_list.html
@@ -72,6 +72,5 @@
   </div>
 {% endblock %}
 
-{% block single_column %}
-  {# prevents page template from inluding primary and secondary columns #}
+{% block secondary %}
 {% endblock %}

--- a/ckanext/nextgeoss/templates/package/read.html
+++ b/ckanext/nextgeoss/templates/package/read.html
@@ -33,7 +33,6 @@
         {% endblock %}
       </h1>
       <h5 class="dataset-detail-title">{{ _('Published by ') }} <a href="{{ org_link }}">{{ org_title }}</a></h5>
-      <h5 class="dataset-detail-title">{{ _('Licensed under ') }} {% snippet "snippets/license_inline.html", pkg_dict=pkg %}</h5>
 
       {% block package_notes %}
          <div class="notes embedded-content dataset-notes">

--- a/ckanext/nextgeoss/templates/package/read.html
+++ b/ckanext/nextgeoss/templates/package/read.html
@@ -74,6 +74,5 @@
 
 {% endblock %}
 
-{% block single_column %}
-  {# prevents page template from inluding primary and secondary columns #}
+{% block secondary %}
 {% endblock %}

--- a/ckanext/nextgeoss/templates/package/read.html
+++ b/ckanext/nextgeoss/templates/package/read.html
@@ -3,6 +3,8 @@
 {% set pkg = c.pkg_dict %}
 {% set org_title = pkg.organization.get('title') or pkg.organization['name'] %}
 {% set org_link = h.url_for(controller='organization', action='read', id=pkg.owner_org) %}
+{% set col_title = pkg.title %}
+{% set col_link = h.get_collection_url(col_title) %}
 {% set thumbnail_path = h.ng_get_dataset_thumbnail_path(pkg) %}
 {% set thumbnail = h.url_for_static(thumbnail_path)%}
 
@@ -23,7 +25,7 @@
       {% endif %}
       <h1 class="dataset-detail-title">
         {% block page_heading %}
-          {{ h.dataset_display_name(pkg) }}
+          {{ pkg.name }}
           {% if pkg.state.startswith('draft') %}
             [{{ _('Draft') }}]
           {% endif %}
@@ -33,16 +35,17 @@
         {% endblock %}
       </h1>
       <h5 class="dataset-detail-title">{{ _('Published by ') }} <a href="{{ org_link }}">{{ org_title }}</a></h5>
+      <h5 class="dataset-detail-title">{{ _('Part of collection ') }} <a href="{{ col_link }}">{{ col_title }}</a></h5>
 
       {% block package_notes %}
          <div class="notes embedded-content dataset-notes">
         {% if pkg.notes %}
           {{ h.render_markdown(h.get_translated(pkg, 'notes')) }}
         {% else %}
-          <p class="empty">{{ _('There is no description for this dataset') }}</p>    
+          <p class="empty">{{ _('There is no description for this dataset') }}</p>
         {% endif %}
         </div>
-      {% endblock %}      
+      {% endblock %}
 
     {% endblock %}
 

--- a/ckanext/nextgeoss/templates/package/resource_read.html
+++ b/ckanext/nextgeoss/templates/package/resource_read.html
@@ -5,6 +5,9 @@
 {% set org_title = pkg.organization.get('title') or pkg.organization['name'] %}
 {% set org_link = h.url_for(controller='organization', action='read', id=pkg.owner_org) %}
 {% set org_logo = pkg.organization.get('image_url') or h.url_for_static('/base/images/placeholder-organization.png')%}
+{% set dataset_name = pkg.name %}
+{% set dataset_link = h.url_for(controller='package', action='read', id=pkg.id) %}
+{% set org_link = h.url_for(controller='organization', action='read', id=pkg.owner_org) %}
 
 {% block head_extras -%}
   {{ super() }}
@@ -26,7 +29,7 @@
   <div class="container single-column">
   {% block resource %}
       {% block resource_inner %}
-        
+
         {% if h.check_access('package_update', {'id':pkg.id }) %}
           <ul class="nav nav-tabs">
             {% block content_primary_nav %}
@@ -46,8 +49,8 @@
         {% block resource_content %}
           {% block resource_read_title %}
             <h1 class="dataset-detail-title">{{ h.resource_display_name(res) | truncate(50) }}</h1>
-            <h5 class="dataset-detail-title">{{ _('Part of dataset ') }} <a href="{{ dataset_link }}">{{ pkg.title }}</a></h5>
             <h5 class="dataset-detail-title">{{ _('Published by ') }} <a href="{{ org_link }}">{{ org_title }}</a></h5>
+            <h5 class="dataset-detail-title">{{ _('Part of dataset ') }} <a href="{{ dataset_link }}">{{ pkg.name }}</a></h5>
           {% endblock %}
 
           {% block resource_read_url %}
@@ -63,13 +66,13 @@
 
           <div class="notes embedded-content dataset-notes" property="rdfs:label">
             {% if res.description %}
-              {{ h.render_markdown('res.description') }}
+              {{ h.render_markdown(res.description) }}
             {% elif not res.description and c.package.notes %}
               <h3>{{ _('From the dataset abstract') }}</h3>
               <blockquote>{{ h.markdown_extract(h.get_translated(c.package, 'notes')) }}</blockquote>
               <p>{% trans dataset=c.package.title, url=h.url_for(controller='package', action='read', id=c.package['name']) %}Source: <a href="{{ url }}">{{ dataset }}</a>{% endtrans %}</p>
             {% else %}
-              <p class="empty">{{ _('There is no description for this resource') }}</p>    
+              <p class="empty">{{ _('There is no description for this resource') }}</p>
             {% endif %}
           </div>
         {% endblock %}
@@ -129,6 +132,5 @@
 
 {% endblock %}
 
-{% block single_column %}
-  {# prevents page template from inluding primary and secondary columns #}
+{% block secondary %}
 {% endblock %}

--- a/ckanext/nextgeoss/templates/package/resource_read.html
+++ b/ckanext/nextgeoss/templates/package/resource_read.html
@@ -48,7 +48,6 @@
             <h1 class="dataset-detail-title">{{ h.resource_display_name(res) | truncate(50) }}</h1>
             <h5 class="dataset-detail-title">{{ _('Part of dataset ') }} <a href="{{ dataset_link }}">{{ pkg.title }}</a></h5>
             <h5 class="dataset-detail-title">{{ _('Published by ') }} <a href="{{ org_link }}">{{ org_title }}</a></h5>
-            <h5 class="dataset-detail-title">{{ _('Licensed under ') }} {% snippet "snippets/license_inline.html", pkg_dict=pkg %}</h5>
           {% endblock %}
 
           {% block resource_read_url %}
@@ -113,10 +112,6 @@
           <tr>
             <th class="dataset-label" scope="row">{{ _('Format') }}</th>
             <td class="dataset-details">{{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}</td>
-          </tr>
-          <tr>
-            <th class="dataset-label" scope="row">{{ _('License') }}</th>
-            <td class="dataset-details">{% snippet "snippets/license.html", pkg_dict=pkg, text_only=True %}</td>
           </tr>
 
           {% for key, value in h.format_resource_items(res.items()) %}

--- a/ckanext/nextgeoss/templates/package/resources.html
+++ b/ckanext/nextgeoss/templates/package/resources.html
@@ -61,6 +61,5 @@
   </div>
 {% endblock %}
 
-{% block single_column %}
-  {# prevents page template from inluding primary and secondary columns #}
+{% block secondary %}
 {% endblock %}

--- a/ckanext/nextgeoss/templates/package/resources.html
+++ b/ckanext/nextgeoss/templates/package/resources.html
@@ -39,7 +39,6 @@
         {% endblock %}
       </h1>
       <h5 class="dataset-detail-title">{{ _('Published by ') }} <a href="{{ org_link }}">{{ org_title }}</a></h5>
-      <h5 class="dataset-detail-title">{{ _('Licensed under ') }} {% snippet "snippets/license_inline.html", pkg_dict=pkg %}</h5>
     {% endblock %}
 
     <section id="dataset-resources" class="resources">


### PR DESCRIPTION
This PR includes some small fixes to the dataset and resource detail pages:
- remove notice about license since we don't have that info yet
- superfluous line from dataset detail pages 
![image](https://user-images.githubusercontent.com/8862002/57529736-edb47b80-7335-11e9-852a-caee95dc6340.png)

- show which collection a dataset belongs to
- show which dataset a resource belongs to