### PR TITLE
Remove Sentinel filters from provider datasets page

### DIFF
--- a/ckanext/nextgeoss/controllers/package.py
+++ b/ckanext/nextgeoss/controllers/package.py
@@ -230,7 +230,9 @@ class NextgeossPackageController(PackageController):
             for plugin in p.PluginImplementations(p.IFacets):
                 facets = plugin.dataset_facets(facets, package_type)
 
-            if collection_params not in collection_names:
+            # Remove Sentinel facets for organizations and non-sentinel collections
+            if collection_params not in collection_names or \
+               package_type == 'organization':
                 for f in facets:
                     if f in sentinel_facet_titles:
                         del facets[f]

--- a/ckanext/nextgeoss/helpers.py
+++ b/ckanext/nextgeoss/helpers.py
@@ -459,3 +459,7 @@ def generate_opensearch_query(params):
                 query = query + '&' + param_tmp + '="' + params[param] + '"'
 
     return query
+
+
+def get_organization_url(organization_name):
+    return "dataset?organization=" + organization_name

--- a/ckanext/nextgeoss/plugin.py
+++ b/ckanext/nextgeoss/plugin.py
@@ -50,6 +50,7 @@ class NextgeossPlugin(plugins.SingletonPlugin):
              'get_collection_url': helpers.get_collection_url,
              'get_collections_dataset_count': helpers.get_collections_dataset_count,
              'get_collections_groups': helpers.get_collections_groups,
+             'get_organization_url': helpers.get_organization_url,
              'nextgeoss_get_facet_title': helpers.nextgeoss_get_facet_title,
              'get_default_slider_values': helpers.get_default_slider_values,
              'get_date_url_param': helpers.get_date_url_param,

--- a/ckanext/nextgeoss/templates/organization/snippets/organization_item.html
+++ b/ckanext/nextgeoss/templates/organization/snippets/organization_item.html
@@ -1,0 +1,38 @@
+{% set url = h.get_organization_url(organization.name) %}
+{% block item %}
+<li class="media-item">
+    {% block item_inner %}
+    {% block image %}
+    <img src="{{ organization.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}" alt="{{ organization.name }}" class="img-responsive media-image">
+    {% endblock %}
+    {% block title %}
+    <h3 class="media-heading">{{ organization.display_name }}</h3>
+    {% endblock %}
+    {% block description %}
+    {% if organization.description %}
+        <p>{{ h.markdown_extract(organization.description, extract_length=80) }}</p>
+    {% endif %}
+    {% endblock %}
+    {% block datasets %}
+    {% if organization.package_count %}
+        <strong class="count">{{ ungettext('{num} Dataset', '{num} Datasets', organization.package_count).format(num=organization.package_count) }}</strong>
+    {% else %}
+        <span class="count">{{ _('0 Datasets') }}</span>
+    {% endif %}
+    {% endblock %}
+    {% block capacity %}
+    {% if show_capacity and organization.capacity %}
+    <p><span class="label label-default">{{ h.roles_translated().get(organization.capacity, organization.capacity) }}</span></p>
+    {% endif %}
+    {% endblock %}
+    {% block link %}
+    <a href="{{ url }}" title="{{ _('View {organization_name}').format(organization_name=organization.display_name) }}" class="media-view">
+    <span>{{ _('View {organization_name}').format(organization_name=organization.display_name) }}</span>
+    </a>
+    {% endblock %}
+    {% endblock %}
+</li>
+{% endblock %}
+{% if position is divisibleby 3 %}
+    <li class="clearfix js-hide"></li>
+{% endif %}


### PR DESCRIPTION
This PR makes the provider listing act the same way the collection listing does: by displaying all the datasets that belong to a certain collection/provider.

So, when users chooses a provider they land on a page like this:

![image](https://user-images.githubusercontent.com/8862002/57766286-608f6f00-7707-11e9-9134-d7f4ba92c417.png)



