### PR TITLE
Display fewer filters for providers

### DIFF
--- a/ckanext/nextgeoss/templates/organization/read.html
+++ b/ckanext/nextgeoss/templates/organization/read.html
@@ -71,13 +71,14 @@
 {% endblock %}
 
 {% block organization_facets %}
+  {% set organization_facets = ['groups', 'collection_name'] %}
   <div class="filters">
     <div>
       <div class="filters-header">
         <i class="fa fa-lg fa-filter"></i>
         <span class="filters-header__title">{{ _('Filters') }}</span>
       </div>
-      {% for facet in c.facet_titles %}
+      {% for facet in organization_facets %}
         {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id':c.group_dict.id}) }}
       {% endfor %}
     </div>


### PR DESCRIPTION
This PR eliminates some of the filters from the provider details page.
I went with this implementation since it seems the most simple and straighforward since it only changes the providers "read" template. You could argue that they are hardcoded in there but it would have been the same if we did it in the controller.

The provider page now looks like this:

![image](https://user-images.githubusercontent.com/8862002/57927117-7a6ab680-78ad-11e9-9f8e-3e78749b17d2.png)
