### PR TITLE
Display collections by newest first

### DIFF
--- a/ckanext/nextgeoss/controller.py
+++ b/ckanext/nextgeoss/controller.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 import ckan.lib.base as base
 import ckan.logic as logic
 import ckan.model as model
@@ -50,8 +52,9 @@ class StaticController(base.BaseController):
 
     def collections(self):
         collection_list = opensearch_config.load_settings("collections_list")
-
-        return base.render('static/collection_list.html', extra_vars={'collection_list': collection_list})
+        collection_list_newest_first = OrderedDict(reversed(collection_list.items()))
+        return base.render('static/collection_list.html',
+            extra_vars={'collection_list': collection_list_newest_first})
 
     def support(self):
         return tk.redirect_to('https://servicedesk.nextgeoss.eu')


### PR DESCRIPTION
This PR changes the way collections are displayed showing the latest ones first. 

For reference, they now look like this:

![image](https://user-images.githubusercontent.com/8862002/57930091-5ad78c00-78b5-11e9-9d1a-528668bbfc02.png)
