### PR TITLE
Fix how selected collection names are displayed in the filters facets

### DIFF
--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -513,7 +513,9 @@ h4.title a {
 }
 
 .nav-item.active > a span, .nav-aside li.active a span {
-  display: inline;
+  overflow: hidden !important;
+  display: inline !important;
+  white-space: normal !important;
 }
 
 .nav-item.active > a:before, .nav-aside li.active a:before {


### PR DESCRIPTION
From this:

![image](https://user-images.githubusercontent.com/8862002/58184640-c94f8c00-7cb1-11e9-93d1-4684fa54624d.png)

To this:

![image](https://user-images.githubusercontent.com/8862002/58184667-d5d3e480-7cb1-11e9-8fb6-a04b05703e73.png)
