### PR TITLE
Remove UUID from  dataset details 

### DIFF
--- a/ckanext/nextgeoss/helpers.py
+++ b/ckanext/nextgeoss/helpers.py
@@ -204,7 +204,8 @@ def get_extras_to_exclude():
         'collection_name',
         'date',
         'product',
-        'noa_expiration_date'
+        'noa_expiration_date',
+        'uuid',
     ]
 
     return extras_to_exclude


### PR DESCRIPTION
Stop displaying `uuid` in dataset details list. 

After the change it looks like this:

![image](https://user-images.githubusercontent.com/8862002/58241658-b5596800-7d4d-11e9-9277-0601bbdf86b2.png)
