### PR TITLE
Fix style issues in dataset details

### DIFF
--- a/ckanext/nextgeoss/helpers.py
+++ b/ckanext/nextgeoss/helpers.py
@@ -244,6 +244,7 @@ def get_extras_to_exclude():
         'collection_name',
         'date',
         'product',
+        'product_url',
         'noa_expiration_date',
         'dataset_extra',
     ]

--- a/ckanext/nextgeoss/helpers.py
+++ b/ckanext/nextgeoss/helpers.py
@@ -244,7 +244,8 @@ def get_extras_to_exclude():
         'collection_name',
         'date',
         'product',
-        'noa_expiration_date'
+        'noa_expiration_date',
+        'dataset_extra',
     ]
 
     return extras_to_exclude

--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -485,6 +485,7 @@ h4.title a {
 .dataset-item-org-logo {
   float: right;
   clear: left;
+  margin-top: 5px !important;
 }
 
 .dataset-item-org-logo .image img {
@@ -539,7 +540,6 @@ h4.title a {
 .dataset-detail-org-logo {
   float: right;
   clear: left;
-  margin-top: 20px;
 }
 
 h1.dataset-detail-title {
@@ -547,8 +547,16 @@ h1.dataset-detail-title {
 }
 
 h5.dataset-detail-title {
-  margin-top: 0px;
   margin-bottom: 5px;
+}
+
+.dataset-detail-title {
+  word-break: break-all;
+  margin-top: 0px !important;
+}
+
+.dataset-intro, .organization-intro {
+  margin-top: 10px !important;
 }
 
 .dataset-notes {

--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -555,7 +555,7 @@ h5.dataset-detail-title {
   margin-top: 0px !important;
 }
 
-.dataset-intro, .organization-intro {
+.dataset-intro, .organization-intro, .group-intro {
   margin-top: 10px !important;
 }
 

--- a/ckanext/nextgeoss/templates/group/activity_stream.html
+++ b/ckanext/nextgeoss/templates/group/activity_stream.html
@@ -6,31 +6,33 @@
     {{ super() }}
 
     {% block package_description %}
-      <div class="dataset-detail-org-logo">
-        <div class="image">
-          <a href="{{ group_url }}">
-            <img src="{{ c.group_dict.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}" height= "100" width="100" alt="{{ c.group_dict.title }}" />
-          </a>
-        </div>
-      </div>
-
-      <h1 class="dataset-detail-title">
-          {% block page_heading %}
-          {% set name = c.group_dict.title or c.group_dict.name %}
-          {{ name }}
-        {% endblock %}
-      </h1>
-
-      <h5 class="dataset-detail-title">Curated by NextGEOSS</h5>
-      <h5 class="dataset-detail-title">More information coming soon</h5>
-
-      {% block package_notes %}
-        {% if c.group_dict.description %}
-          <div class="notes embedded-content dataset-notes">
-            {{ h.render_markdown(_(c.group_dict.description)) }}
+      <div class="group-intro">
+        <div class="dataset-detail-org-logo">
+          <div class="image">
+            <a href="{{ group_url }}">
+              <img src="{{ c.group_dict.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}" height= "100" width="100" alt="{{ c.group_dict.title }}" />
+            </a>
           </div>
-        {% endif %}
-      {% endblock %}
+        </div>
+
+        <h1 class="dataset-detail-title">
+            {% block page_heading %}
+            {% set name = c.group_dict.title or c.group_dict.name %}
+            {{ name }}
+          {% endblock %}
+        </h1>
+
+        <h5 class="dataset-detail-title">Curated by NextGEOSS</h5>
+        <h5 class="dataset-detail-title">More information coming soon</h5>
+
+        {% block package_notes %}
+          {% if c.group_dict.description %}
+            <div class="notes embedded-content dataset-notes">
+              {{ h.render_markdown(_(c.group_dict.description)) }}
+            </div>
+          {% endif %}
+        {% endblock %}
+      </div>
     {% endblock %}
   </div>
 {% endblock %}

--- a/ckanext/nextgeoss/templates/group/read_base_primary.html
+++ b/ckanext/nextgeoss/templates/group/read_base_primary.html
@@ -13,30 +13,33 @@
     {{ super() }}
 
     {% block package_description %}
-      <div class="dataset-detail-org-logo">
-        <div class="image">
-          <a href="{{ group_url }}">
-            <img src="{{ c.group_dict.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}" height= "100" width="100" alt="{{ c.group_dict.title }}" />
-          </a>
-        </div>
-      </div>
-
-      <h1 class="dataset-detail-title">
-          {% block page_heading %}
-          {% set name = c.group_dict.title or c.group_dict.name %}
-          {{ name }}
-        {% endblock %}
-      </h1>
-
-      <h5 class="dataset-detail-title">Curated by NextGEOSS</h5>
-
-      {% block package_notes %}
-        {% if c.group_dict.description %}
-          <div data-module='nextgeoss_read_more_paragraph' class="notes embedded-content dataset-notes">
-            {{ h.render_markdown(_(c.group_dict.description)) }}
+      <div class="group-intro">
+          <div class="dataset-detail-org-logo">
+            <div class="image">
+              <a href="{{ group_url }}">
+                <img src="{{ c.group_dict.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}" height= "100" width="100" alt="{{ c.group_dict.title }}" />
+              </a>
+            </div>
           </div>
-        {% endif %}
-      {% endblock %}
+
+          <h1 class="dataset-detail-title">
+              {% block page_heading %}
+              {% set name = c.group_dict.title or c.group_dict.name %}
+              {{ name }}
+            {% endblock %}
+          </h1>
+
+          <h5 class="dataset-detail-title">Curated by NextGEOSS</h5>
+          <h5 class="dataset-detail-title">More information coming soon</h5>
+
+          {% block package_notes %}
+            {% if c.group_dict.description %}
+              <div class="notes embedded-content dataset-notes">
+                {{ h.render_markdown(_(c.group_dict.description)) }}
+              </div>
+            {% endif %}
+          {% endblock %}
+      </div>
     {% endblock %}
 
     {% if c.group_dict.name == 'agriculture_monitoring' %}

--- a/ckanext/nextgeoss/templates/organization/read.html
+++ b/ckanext/nextgeoss/templates/organization/read.html
@@ -6,28 +6,30 @@
     {{ super() }}
 
     {% block package_description %}
-      <div class="dataset-detail-org-logo">
-        <div class="image">
-          <a href="{{ org_link }}">
-            <img src="{{ c.group_dict.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}" height= "100" width="100" alt="{{ c.group_dict.title }}" />
-          </a>
-        </div>
-      </div>
-
-      <h1 class="dataset-detail-title">
-        {% block page_heading %}
-          {% set name = c.group_dict.title or c.group_dict.name %}
-          {{ name }}
-        {% endblock %}
-      </h1>
-
-      {% block package_notes %}
-        {% if c.group_dict.description %}
-          <div class="notes embedded-content dataset-notes">
-            {{ h.render_markdown(_(c.group_dict.description)) }}
+      <div class="organization-intro">
+        <div class="dataset-detail-org-logo">
+          <div class="image">
+            <a href="{{ org_link }}">
+              <img src="{{ c.group_dict.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}" height= "100" width="100" alt="{{ c.group_dict.title }}" />
+            </a>
           </div>
-        {% endif %}
-      {% endblock %}
+        </div>
+
+        <h1 class="dataset-detail-title">
+          {% block page_heading %}
+            {% set name = c.group_dict.title or c.group_dict.name %}
+            {{ name }}
+          {% endblock %}
+        </h1>
+
+        {% block package_notes %}
+          {% if c.group_dict.description %}
+            <div class="notes embedded-content dataset-notes">
+              {{ h.render_markdown(_(c.group_dict.description)) }}
+            </div>
+          {% endif %}
+        {% endblock %}
+      </div>
     {% endblock %}
   </div>
 {% endblock %}

--- a/ckanext/nextgeoss/templates/package/activity.html
+++ b/ckanext/nextgeoss/templates/package/activity.html
@@ -12,29 +12,7 @@
   <div class="container single-column">
     {% snippet "package/snippets/nav_tabs.html", pkg=pkg %}
     {% block package_description %}
-      <div class="dataset-detail-org-logo">
-        <div class="image">
-          <img src="{{ thumbnail }}" height= "210" width="210" alt="{{ pkg.name}} thumbnail" />
-        </div>
-      </div>
-      {% if pkg.private %}
-        <span class="dataset-private label label-inverse pull-right">
-          <i class="fa fa-lock"></i>
-          {{ _('Private') }}
-        </span>
-      {% endif %}
-      <h1 class="dataset-detail-title">
-        {% block page_heading %}
-          {{ h.dataset_display_name(pkg) }}
-          {% if pkg.state.startswith('draft') %}
-            [{{ _('Draft') }}]
-          {% endif %}
-          {% if pkg.state == 'deleted' %}
-            [{{ _('Deleted') }}]
-          {% endif %}
-        {% endblock %}
-      </h1>
-      <h5 class="dataset-detail-title">{{ _('Published by ') }} <a href="{{ org_link }}">{{ org_title }}</a></h5>
+      {{ super() }}
     {% endblock %}
 
     <section class="additional-info">

--- a/ckanext/nextgeoss/templates/package/base.html
+++ b/ckanext/nextgeoss/templates/package/base.html
@@ -22,3 +22,34 @@
     <li class="active"><a href="">{{ _('Create Dataset') }}</a></li>
   {% endif %}
 {% endblock %}
+
+{% block pre_primary %}
+    {% block package_description %}
+      <div class="dataset-intro">
+        <div class="dataset-detail-org-logo">
+          <div class="image">
+            <img src="{{ thumbnail }}" height= "210" width="210" alt="{{ pkg.name}} thumbnail" />
+          </div>
+        </div>
+        {% if pkg.private %}
+          <span class="dataset-private label label-inverse pull-right">
+            <i class="fa fa-lock"></i>
+            {{ _('Private') }}
+          </span>
+        {% endif %}
+        <h1 class="dataset-detail-title">
+          {% block page_heading %}
+            {{ pkg.name }}
+            {% if pkg.state.startswith('draft') %}
+              [{{ _('Draft') }}]
+            {% endif %}
+            {% if pkg.state == 'deleted' %}
+              [{{ _('Deleted') }}]
+            {% endif %}
+          {% endblock %}
+        </h1>
+        <h5 class="dataset-detail-title">{{ _('Published by ') }} <a href="{{ org_link }}">{{ org_title }}</a></h5>
+        <h5 class="dataset-detail-title">{{ _('Part of collection ') }} <a href="{{ col_link }}">{{ col_title }}</a></h5>
+      </div>
+    {% endblock %}
+{% endblock %}

--- a/ckanext/nextgeoss/templates/package/edit.html
+++ b/ckanext/nextgeoss/templates/package/edit.html
@@ -10,33 +10,7 @@
   <div class="container single-column">
   {% snippet "package/snippets/edit_tabs.html", pkg=pkg %}
   {% block package_description %}
-    <div class="dataset-detail-org-logo">
-      <div class="image">
-        <a href="{{ org_link }}">
-          <img src="{{ org_logo }}" height= "100" width="100" alt="{{ org_title }}" />
-        </a>
-      </div>
-    </div>
-
-    {% if pkg.private %}
-      <span class="dataset-private label label-inverse pull-right">
-        <i class="fa fa-lock"></i>
-        {{ _('Private') }}
-      </span>
-    {% endif %}
-
-    <h1 class="dataset-detail-title">
-      {% block page_heading %}
-        {{ h.dataset_display_name(pkg) }}
-        {% if pkg.state.startswith('draft') %}
-          [{{ _('Draft') }}]
-        {% endif %}
-        {% if pkg.state == 'deleted' %}
-          [{{ _('Deleted') }}]
-        {% endif %}
-      {% endblock %}
-    </h1>
-    <h5 class="dataset-detail-title">{{ _('Published by ') }} <a href="{{ org_link }}">{{ org_title }}</a></h5>
+    {{ super() }}
   {% endblock %}
 
   <section class="edit-dataset-info">

--- a/ckanext/nextgeoss/templates/package/group_list.html
+++ b/ckanext/nextgeoss/templates/package/group_list.html
@@ -15,29 +15,7 @@
   <div class="container single-column">
     {% snippet "package/snippets/nav_tabs.html", pkg=pkg %}
     {% block package_description %}
-      <div class="dataset-detail-org-logo">
-        <div class="image">
-          <img src="{{ thumbnail }}" height= "210" width="210" alt="{{ pkg.name}} thumbnail" />
-        </div>
-      </div>
-      {% if pkg.private %}
-        <span class="dataset-private label label-inverse pull-right">
-          <i class="fa fa-lock"></i>
-          {{ _('Private') }}
-        </span>
-      {% endif %}
-      <h1 class="dataset-detail-title">
-        {% block page_heading %}
-          {{ h.dataset_display_name(pkg) }}
-          {% if pkg.state.startswith('draft') %}
-            [{{ _('Draft') }}]
-          {% endif %}
-          {% if pkg.state == 'deleted' %}
-            [{{ _('Deleted') }}]
-          {% endif %}
-        {% endblock %}
-      </h1>
-      <h5 class="dataset-detail-title">{{ _('Published by ') }} <a href="{{ org_link }}">{{ org_title }}</a></h5>
+      {{ super() }}
     {% endblock %}
 
     <section class="additional-info">

--- a/ckanext/nextgeoss/templates/package/read.html
+++ b/ckanext/nextgeoss/templates/package/read.html
@@ -12,30 +12,7 @@
   <div class="container single-column">
     {% snippet "package/snippets/nav_tabs.html", pkg=pkg %}
     {% block package_description %}
-      <div class="dataset-detail-org-logo">
-        <div class="image">
-		      <img src="{{ thumbnail }}" height= "210" width="210" alt="{{ pkg.name}} thumbnail" />
-        </div>
-      </div>
-      {% if pkg.private %}
-        <span class="dataset-private label label-inverse pull-right">
-          <i class="fa fa-lock"></i>
-          {{ _('Private') }}
-        </span>
-      {% endif %}
-      <h1 class="dataset-detail-title">
-        {% block page_heading %}
-          {{ pkg.name }}
-          {% if pkg.state.startswith('draft') %}
-            [{{ _('Draft') }}]
-          {% endif %}
-          {% if pkg.state == 'deleted' %}
-            [{{ _('Deleted') }}]
-          {% endif %}
-        {% endblock %}
-      </h1>
-      <h5 class="dataset-detail-title">{{ _('Published by ') }} <a href="{{ org_link }}">{{ org_title }}</a></h5>
-      <h5 class="dataset-detail-title">{{ _('Part of collection ') }} <a href="{{ col_link }}">{{ col_title }}</a></h5>
+      {{ super() }}
 
       {% block package_notes %}
          <div class="notes embedded-content dataset-notes">

--- a/ckanext/nextgeoss/templates/package/read_base.html
+++ b/ckanext/nextgeoss/templates/package/read_base.html
@@ -22,4 +22,5 @@
       {% endif %}
     {% endblock %}
 
+    {{ super() }}
 {% endblock %}

--- a/ckanext/nextgeoss/templates/package/resources.html
+++ b/ckanext/nextgeoss/templates/package/resources.html
@@ -14,31 +14,7 @@
   <div class="container single-column">
     {% snippet "package/snippets/edit_tabs.html", pkg=pkg %}
     {% block package_description %}
-      <div class="dataset-detail-org-logo">
-        <div class="image">
-          <a href="{{ org_link }}">
-            <img src="{{ org_logo }}" height= "100" width="100" alt="{{ org_title }}" />
-          </a>
-        </div>
-      </div>
-      {% if pkg.private %}
-        <span class="dataset-private label label-inverse pull-right">
-          <i class="fa fa-lock"></i>
-          {{ _('Private') }}
-        </span>
-      {% endif %}
-      <h1 class="dataset-detail-title">
-        {% block page_heading %}
-          {{ h.dataset_display_name(pkg) }}
-          {% if pkg.state.startswith('draft') %}
-            [{{ _('Draft') }}]
-          {% endif %}
-          {% if pkg.state == 'deleted' %}
-            [{{ _('Deleted') }}]
-          {% endif %}
-        {% endblock %}
-      </h1>
-      <h5 class="dataset-detail-title">{{ _('Published by ') }} <a href="{{ org_link }}">{{ org_title }}</a></h5>
+      {{ super() }}
     {% endblock %}
 
     <section id="dataset-resources" class="resources">

--- a/ckanext/nextgeoss/templates/package/snippets/additional_info.html
+++ b/ckanext/nextgeoss/templates/package/snippets/additional_info.html
@@ -45,6 +45,18 @@
           </tr>
         {% endif %}
 
+        {% block extras scoped %}
+          {% set exclude = h.ng_extras_to_exclude() %}
+          {% set subs = h.ng_extra_names() %}
+          {% for extra in h.sorted_extras(pkg_dict.extras, subs=subs, exclude=exclude) %}
+            {% set key, value = extra %}
+              <tr rel="dc:relation" resource="_:extra{{ i }}">
+                <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key) }}</th>
+                <td class="dataset-details" property="rdf:value">{{ value }}</td>
+              </tr>
+          {% endfor %}
+        {% endblock %}
+
         {% if pkg_dict.metadata_modified %}
           <tr>
             <th scope="row" class="dataset-label">{{ _("Metadata Updated on NextGEOSS Catalogue") }}</th>
@@ -62,18 +74,6 @@
             </td>
           </tr>
         {% endif %}
-
-      {% block extras scoped %}
-        {% set exclude = h.ng_extras_to_exclude() %}
-        {% set subs = h.ng_extra_names() %}
-        {% for extra in h.sorted_extras(pkg_dict.extras, subs=subs, exclude=exclude) %}
-          {% set key, value = extra %}
-            <tr rel="dc:relation" resource="_:extra{{ i }}">
-              <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key) }}</th>
-              <td class="dataset-details" property="rdf:value">{{ value }}</td>
-            </tr>
-        {% endfor %}
-      {% endblock %}
 
       {% endblock %}
     </tbody>


### PR DESCRIPTION
This PR fixes some issues in detaset details page and all the other pages that misuse the `dataset-details-title` and `dataset-details-logo` classes. 

Ideally we shouldn't reuse CSS classes like that but since we lack LESS and inheritance is not possible in CSS I went for the next best thing which was to wrap them in another thematic class (e.g. `dataset-intro`, `organization-intro`, etc.). I also refactored a bit the templates to make sure the intro is only defined in the base template.

Fixes include:
- fixed alignment for long titles
- removed the `data_extra` field in dataset details
- moved the `Metadata Updated on NextGEOSS Catalogue` at the end of the list

:warning:  The branch is based on another feature branch. I needed that code for applying the changes to topic pages. Please make sure you [merge that PR](https://github.com/NextGeoss/ckanext-nextgeoss/pull/87) _before this one_. 