### PR TITLE
Fix dataset collection links

### DIFF
--- a/ckanext/nextgeoss/helpers.py
+++ b/ckanext/nextgeoss/helpers.py
@@ -307,7 +307,7 @@ def get_collections_count():
 def get_collection_url(collection_name):
     collection = 'collection_id:' + collection_name
 
-    return "dataset?collection_name=" + collection_name.replace(' ', '+')
+    return "/dataset?collection_name=" + collection_name.replace(' ', '+')
 
 
 def get_collections_dataset_count(collection_name):

--- a/ckanext/nextgeoss/templates/package/read.html
+++ b/ckanext/nextgeoss/templates/package/read.html
@@ -4,7 +4,8 @@
 {% set org_title = pkg.organization.get('title') or pkg.organization['name'] %}
 {% set org_link = h.url_for(controller='organization', action='read', id=pkg.owner_org) %}
 {% set col_title = pkg.title %}
-{% set col_link = h.get_collection_url(col_title) %}
+{% set col_name = h.get_extras_value(pkg.extras, 'collection_name') %}
+{% set col_link = h.get_collection_url(col_name) %}
 {% set thumbnail_path = h.ng_get_dataset_thumbnail_path(pkg) %}
 
 {% block pre_primary %}
@@ -37,17 +38,20 @@
             {% endblock %}
           </h1>
           <h5 class="dataset-detail-title">{{ _('Published by ') }} <a href="{{ org_link }}">{{ org_title }}</a></h5>
-          <h5 class="dataset-detail-title">{{ _('Part of collection ') }} <a href="{{ col_link }}">{{ col_title }}</a></h5>
+          {% if col_name is not none %}
+            <h5 class="dataset-detail-title">{{ _('Part of collection ') }} <a href="{{ col_link }}">{{ col_title }}</a></h5>
+          {% endif %}
+        {% endblock %}
 
-          {% block package_notes %}
-              <div class="notes embedded-content dataset-notes">
-            {% if pkg.notes %}
-              {{ h.render_markdown(h.get_translated(pkg, 'notes')) }}
-            {% else %}
-              <p class="empty">{{ _('There is no description for this dataset') }}</p>
-            {% endif %}
-            </div>
-          {% endblock %}
+        {% block package_notes %}
+            <div class="notes embedded-content dataset-notes">
+          {% if pkg.notes %}
+            {{ h.render_markdown(h.get_translated(pkg, 'notes')) }}
+          {% else %}
+            <p class="empty">{{ _('There is no description for this dataset') }}</p>
+          {% endif %}
+          </div>
+        {% endblock %}
       </div>
 
     {% endblock %}

--- a/ckanext/nextgeoss/templates/snippets/package_item.html
+++ b/ckanext/nextgeoss/templates/snippets/package_item.html
@@ -49,8 +49,8 @@
   <div class="dataset-item-org-license">
       {% set collection_name = h.get_extras_value(package.extras, 'collection_name') %}
       {% if collection_name is not none %}
-        {% set collection_url = "/dataset?collection_name=" + collection_name.replace(' ', '+') %}
-          <b> Collection: </b>  <a href="{{ collection_url }}"> {{ collection_name }} </a>
+        {% set collection_url = h.get_collection_url(collection_name) %}
+          <b> Collection: </b>  <a href="{{ collection_url }}"> {{ package.title }} </a>
       {% endif %}
   </div>
 


### PR DESCRIPTION
When the user clicks on the collection name it should be redirected to the collection page i.e. list of datasets filtered by that collection's name.

That redirect link was broken and this PR fixes it. 