### PR TITLE
Fix tooltips alignment

### DIFF
--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -1393,10 +1393,9 @@ table.mobile-table td.dataset-details {
 }
 
 .help-tip{
-    position: absolute;
-    top: 18px;
-    right: 18px;
+    position: relative;
     text-align: center;
+    align-self: center;
     background-color: #BCDBEA;
     border-radius: 50%;
     width: 24px;
@@ -1427,7 +1426,6 @@ table.mobile-table td.dataset-details {
     background-color: #1E2021;
     padding: 20px;
     width: 300px;
-    position: absolute;
     border-radius: 3px;
     box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.2);
     right: -4px;
@@ -1451,9 +1449,14 @@ table.mobile-table td.dataset-details {
     width:100%;
     height:40px;
     content:'';
-    position: absolute;
     top:-40px;
     left:0;
+}
+
+.navbar-help-tip{
+  width: 20px;
+  height: 19px;
+  font-size: 13px;
 }
 
 /* CSS animation */

--- a/ckanext/nextgeoss/templates/snippets/facet_list.html
+++ b/ckanext/nextgeoss/templates/snippets/facet_list.html
@@ -63,7 +63,7 @@ within_tertiary
               {% set title = title or h.nextgeoss_get_facet_title(name) %}
               {{ _(title) }}
 
-              <div class="help-tip">
+              <div class="help-tip navbar-help-tip">
                 <p>List of available {{title}}. Select {{title}} to query by.</p>
               </div>
             </h2>


### PR DESCRIPTION
Most of our tooltips were floating around the page:

![image](https://user-images.githubusercontent.com/8862002/59119967-7d107700-8954-11e9-862c-85a56ef73b40.png)

This PR aims to fix that. Also the ones that were previously undisclosed because of a bug are now going to be displayed (especially those in the navbar):

![image](https://user-images.githubusercontent.com/8862002/59120041-ae894280-8954-11e9-90e5-714a70839d95.png)
