### PR TITLE
Fix style issues in dataset details

### DIFF
--- a/ckanext/nextgeoss/helpers.py
+++ b/ckanext/nextgeoss/helpers.py
@@ -248,6 +248,7 @@ def get_extras_to_exclude():
         'product',
         'noa_expiration_date',
         'uuid',
+        'dataset_extra',
     ]
 
     return extras_to_exclude

--- a/ckanext/nextgeoss/helpers.py
+++ b/ckanext/nextgeoss/helpers.py
@@ -246,6 +246,7 @@ def get_extras_to_exclude():
         'collection_name',
         'date',
         'product',
+        'product_url',
         'noa_expiration_date',
         'uuid',
         'dataset_extra',

--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -488,6 +488,7 @@ h4.title a {
 .dataset-item-org-logo {
   float: right;
   clear: left;
+  margin-top: 5px !important;
 }
 
 .dataset-item-org-logo .image img {
@@ -544,7 +545,6 @@ h4.title a {
 .dataset-detail-org-logo {
   float: right;
   clear: left;
-  margin-top: 20px;
 }
 
 h1.dataset-detail-title {
@@ -552,8 +552,16 @@ h1.dataset-detail-title {
 }
 
 h5.dataset-detail-title {
-  margin-top: 0px;
   margin-bottom: 5px;
+}
+
+.dataset-detail-title {
+  word-break: break-all;
+  margin-top: 0px !important;
+}
+
+.dataset-intro, .organization-intro {
+  margin-top: 10px !important;
 }
 
 .dataset-notes {

--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -560,7 +560,7 @@ h5.dataset-detail-title {
   margin-top: 0px !important;
 }
 
-.dataset-intro, .organization-intro {
+.dataset-intro, .organization-intro, .group-intro {
   margin-top: 10px !important;
 }
 

--- a/ckanext/nextgeoss/templates/group/about.html
+++ b/ckanext/nextgeoss/templates/group/about.html
@@ -11,4 +11,3 @@
     {% snippet 'group/snippets/additional_info.html', extras = h.sorted_extras(c.group_dict.extras), name=c.group_dict.name %}
   {% endblock %}
 {% endblock %}
-{% endblock %}

--- a/ckanext/nextgeoss/templates/group/activity_stream.html
+++ b/ckanext/nextgeoss/templates/group/activity_stream.html
@@ -6,10 +6,10 @@
     {{ super() }}
 
     {% block package_description %}
-      <div class="dataset-detail">
+      <div class="group-intro">
         <div class="dataset-detail-org-logo">
           <div class="image">
-            <a href="{{ group_url }}"></a>
+            <a href="{{ group_url }}">
               <img src="{{ c.group_dict.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}" height= "100" width="100" alt="{{ c.group_dict.title }}" />
             </a>
           </div>

--- a/ckanext/nextgeoss/templates/group/read_base_primary.html
+++ b/ckanext/nextgeoss/templates/group/read_base_primary.html
@@ -13,30 +13,33 @@
     {{ super() }}
 
     {% block package_description %}
-      <div class="dataset-detail-org-logo">
-        <div class="image">
-          <a href="{{ group_url }}">
-            <img src="{{ c.group_dict.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}" height= "100" width="100" alt="{{ c.group_dict.title }}" />
-          </a>
-        </div>
-      </div>
-
-      <h1 class="dataset-detail-title">
-          {% block page_heading %}
-          {% set name = c.group_dict.title or c.group_dict.name %}
-          {{ name }}
-        {% endblock %}
-      </h1>
-
-      <h5 class="dataset-detail-title">Curated by NextGEOSS</h5>
-
-      {% block package_notes %}
-        {% if c.group_dict.description %}
-          <div data-module='nextgeoss_read_more_paragraph' class="notes embedded-content dataset-notes">
-            {{ h.render_markdown(_(c.group_dict.description)) }}
+      <div class="group-intro">
+          <div class="dataset-detail-org-logo">
+            <div class="image">
+              <a href="{{ group_url }}">
+                <img src="{{ c.group_dict.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}" height= "100" width="100" alt="{{ c.group_dict.title }}" />
+              </a>
+            </div>
           </div>
-        {% endif %}
-      {% endblock %}
+
+          <h1 class="dataset-detail-title">
+              {% block page_heading %}
+              {% set name = c.group_dict.title or c.group_dict.name %}
+              {{ name }}
+            {% endblock %}
+          </h1>
+
+          <h5 class="dataset-detail-title">Curated by NextGEOSS</h5>
+          <h5 class="dataset-detail-title">More information coming soon</h5>
+
+          {% block package_notes %}
+            {% if c.group_dict.description %}
+              <div class="notes embedded-content dataset-notes">
+                {{ h.render_markdown(_(c.group_dict.description)) }}
+              </div>
+            {% endif %}
+          {% endblock %}
+      </div>
     {% endblock %}
 
     {% if c.group_dict.name == 'agriculture_monitoring' %}

--- a/ckanext/nextgeoss/templates/organization/read.html
+++ b/ckanext/nextgeoss/templates/organization/read.html
@@ -6,8 +6,7 @@
     {{ super() }}
 
     {% block package_description %}
-      <div class="dataset-detail">
-
+      <div class="organization-intro">
         <div class="dataset-detail-org-logo">
           <div class="image">
             <a href="{{ org_link }}">

--- a/ckanext/nextgeoss/templates/package/activity.html
+++ b/ckanext/nextgeoss/templates/package/activity.html
@@ -11,31 +11,7 @@
   <div class="container single-column">
     {% snippet "package/snippets/nav_tabs.html", pkg=pkg %}
     {% block package_description %}
-      <div class="dataset-detail">
-        <div class="dataset-detail-org-logo">
-          <div class="image">
-            <img src="{{ thumbnail_path }}" height= "210" width="210" alt="{{ thumbnail_path }}" />
-          </div>
-        </div>
-        {% if pkg.private %}
-          <span class="dataset-private label label-inverse pull-right">
-            <i class="fa fa-lock"></i>
-            {{ _('Private') }}
-          </span>
-        {% endif %}
-        <h1 class="dataset-detail-title">
-          {% block page_heading %}
-            {{ h.dataset_display_name(pkg) }}
-            {% if pkg.state.startswith('draft') %}
-              [{{ _('Draft') }}]
-            {% endif %}
-            {% if pkg.state == 'deleted' %}
-              [{{ _('Deleted') }}]
-            {% endif %}
-          {% endblock %}
-        </h1>
-        <h5 class="dataset-detail-title">{{ _('Published by ') }} <a href="{{ org_link }}">{{ org_title }}</a></h5>
-      </div>
+      {{ super() }}
     {% endblock %}
 
     <section class="additional-info">

--- a/ckanext/nextgeoss/templates/package/activity.html
+++ b/ckanext/nextgeoss/templates/package/activity.html
@@ -1,9 +1,6 @@
 {% extends "package/read_base.html" %}
 
 {% set pkg = c.pkg_dict %}
-{% set org_title = pkg.organization.get('title') or pkg.organization['name'] %}
-{% set org_link = h.url_for(controller='organization', action='read', id=pkg.owner_org) %}
-{% set thumbnail_path = h.ng_get_dataset_thumbnail_path(pkg) %}
 
 {% block subtitle %}{{ _('Activity Stream') }} - {{ super() }}{% endblock %}
 

--- a/ckanext/nextgeoss/templates/package/base.html
+++ b/ckanext/nextgeoss/templates/package/base.html
@@ -1,7 +1,12 @@
 {% extends "page.html" %}
 
 {% set pkg = c.pkg_dict or pkg_dict %}
-
+{% set thumbnail = h.ng_get_dataset_thumbnail_path(pkg) %}
+{% set org_title = pkg.organization.get('title') or pkg.organization['name'] %}
+{% set org_link = h.url_for(controller='organization', action='read', id=pkg.owner_org) %}
+{% set col_title = pkg.title %}
+{% set col_name = h.get_extras_value(pkg.extras, 'collection_name') %}
+{% set col_link = h.get_collection_url(col_name) %}
 {% block breadcrumb_content_selected %} class="active"{% endblock %}
 
 {% block subtitle %}{{ _('Datasets') }}{% endblock %}

--- a/ckanext/nextgeoss/templates/package/base.html
+++ b/ckanext/nextgeoss/templates/package/base.html
@@ -22,3 +22,34 @@
     <li class="active"><a href="">{{ _('Create Dataset') }}</a></li>
   {% endif %}
 {% endblock %}
+
+{% block pre_primary %}
+    {% block package_description %}
+      <div class="dataset-intro">
+        <div class="dataset-detail-org-logo">
+          <div class="image">
+            <img src="{{ thumbnail }}" height= "210" width="210" alt="{{ pkg.name}} thumbnail" />
+          </div>
+        </div>
+        {% if pkg.private %}
+          <span class="dataset-private label label-inverse pull-right">
+            <i class="fa fa-lock"></i>
+            {{ _('Private') }}
+          </span>
+        {% endif %}
+        <h1 class="dataset-detail-title">
+          {% block page_heading %}
+            {{ pkg.name }}
+            {% if pkg.state.startswith('draft') %}
+              [{{ _('Draft') }}]
+            {% endif %}
+            {% if pkg.state == 'deleted' %}
+              [{{ _('Deleted') }}]
+            {% endif %}
+          {% endblock %}
+        </h1>
+        <h5 class="dataset-detail-title">{{ _('Published by ') }} <a href="{{ org_link }}">{{ org_title }}</a></h5>
+        <h5 class="dataset-detail-title">{{ _('Part of collection ') }} <a href="{{ col_link }}">{{ col_title }}</a></h5>
+      </div>
+    {% endblock %}
+{% endblock %}

--- a/ckanext/nextgeoss/templates/package/edit.html
+++ b/ckanext/nextgeoss/templates/package/edit.html
@@ -1,10 +1,6 @@
 {% extends 'package/edit_base.html' %}
 
 {% set pkg = c.pkg_dict %}
-{% set org_title = pkg.organization.get('title') or pkg.organization['name'] %}
-{% set org_link = h.url_for(controller='organization', action='read', id=pkg.owner_org) %}
-{% set thumbnail_path = h.ng_get_dataset_thumbnail_path(pkg) %}
-
 
 {% block pre_primary %}
   <div class="container single-column">

--- a/ckanext/nextgeoss/templates/package/edit.html
+++ b/ckanext/nextgeoss/templates/package/edit.html
@@ -10,36 +10,7 @@
   <div class="container single-column">
   {% snippet "package/snippets/edit_tabs.html", pkg=pkg %}
   {% block package_description %}
-    <div class="dataset-detail">
-
-      <div class="dataset-detail-org-logo">
-        <div class="image">
-          <a href="{{ org_link }}">
-            <img src="{{ thumbnail_path }}" height= "210" width="210" alt="{{ thumbnail_path }}" />
-          </a>
-        </div>
-      </div>
-
-      {% if pkg.private %}
-        <span class="dataset-private label label-inverse pull-right">
-          <i class="fa fa-lock"></i>
-          {{ _('Private') }}
-        </span>
-      {% endif %}
-
-      <h1 class="dataset-detail-title">
-        {% block page_heading %}
-          {{ h.dataset_display_name(pkg) }}
-          {% if pkg.state.startswith('draft') %}
-            [{{ _('Draft') }}]
-          {% endif %}
-          {% if pkg.state == 'deleted' %}
-            [{{ _('Deleted') }}]
-          {% endif %}
-        {% endblock %}
-      </h1>
-      <h5 class="dataset-detail-title">{{ _('Published by ') }} <a href="{{ org_link }}">{{ org_title }}</a></h5>
-    </div>
+    {{ super() }}
   {% endblock %}
 
   <section class="edit-dataset-info">

--- a/ckanext/nextgeoss/templates/package/group_list.html
+++ b/ckanext/nextgeoss/templates/package/group_list.html
@@ -2,9 +2,6 @@
 {% import 'macros/form.html' as form %}
 
 {% set pkg = c.pkg_dict %}
-{% set org_title = pkg.organization.get('title') or pkg.organization['name'] %}
-{% set org_link = h.url_for(controller='organization', action='read', id=pkg.owner_org) %}
-{% set thumbnail_path = h.ng_get_dataset_thumbnail_path(pkg) %}
 
 {% block subtitle %}
   {{ _('Topics') }} - {{ super() }}

--- a/ckanext/nextgeoss/templates/package/group_list.html
+++ b/ckanext/nextgeoss/templates/package/group_list.html
@@ -14,31 +14,7 @@
   <div class="container single-column">
     {% snippet "package/snippets/nav_tabs.html", pkg=pkg %}
     {% block package_description %}
-      <div class="dataset-detail">
-        <div class="dataset-detail-org-logo">
-          <div class="image">
-            <img src="{{ thumbnail_path }}" height= "210" width="210" alt="{{ thumbnail_path }}" />
-          </div>
-        </div>
-        {% if pkg.private %}
-          <span class="dataset-private label label-inverse pull-right">
-            <i class="fa fa-lock"></i>
-            {{ _('Private') }}
-          </span>
-        {% endif %}
-        <h1 class="dataset-detail-title">
-          {% block page_heading %}
-            {{ h.dataset_display_name(pkg) }}
-            {% if pkg.state.startswith('draft') %}
-              [{{ _('Draft') }}]
-            {% endif %}
-            {% if pkg.state == 'deleted' %}
-              [{{ _('Deleted') }}]
-            {% endif %}
-          {% endblock %}
-        </h1>
-        <h5 class="dataset-detail-title">{{ _('Published by ') }} <a href="{{ org_link }}">{{ org_title }}</a></h5>
-      </div>
+      {{ super() }}
     {% endblock %}
 
     <section class="additional-info">

--- a/ckanext/nextgeoss/templates/package/read.html
+++ b/ckanext/nextgeoss/templates/package/read.html
@@ -12,36 +12,7 @@
   <div class="container single-column">
     {% snippet "package/snippets/nav_tabs.html", pkg=pkg %}
     {% block package_description %}
-      <div class="dataset-detail">
-        <div class="dataset-detail-org-logo">
-            <div class="image">
-              <a href="{{ org_link }}">
-                <img src="{{ thumbnail_path }}" height= "210" width="210" alt="{{ thumbnail_path }}" />
-              </a>
-            </div>
-          </div>
-          {% if pkg.private %}
-            <span class="dataset-private label label-inverse pull-right">
-              <i class="fa fa-lock"></i>
-              {{ _('Private') }}
-            </span>
-          {% endif %}
-          <h1 class="dataset-detail-title">
-            {% block page_heading %}
-              {{ pkg.name }}
-              {% if pkg.state.startswith('draft') %}
-                [{{ _('Draft') }}]
-              {% endif %}
-              {% if pkg.state == 'deleted' %}
-                [{{ _('Deleted') }}]
-              {% endif %}
-            {% endblock %}
-          </h1>
-          <h5 class="dataset-detail-title">{{ _('Published by ') }} <a href="{{ org_link }}">{{ org_title }}</a></h5>
-          {% if col_name is not none %}
-            <h5 class="dataset-detail-title">{{ _('Part of collection ') }} <a href="{{ col_link }}">{{ col_title }}</a></h5>
-          {% endif %}
-        {% endblock %}
+        {{ super() }}
 
         {% block package_notes %}
             <div class="notes embedded-content dataset-notes">

--- a/ckanext/nextgeoss/templates/package/read.html
+++ b/ckanext/nextgeoss/templates/package/read.html
@@ -1,12 +1,6 @@
 {% extends "package/read_base.html" %}
 
 {% set pkg = c.pkg_dict %}
-{% set org_title = pkg.organization.get('title') or pkg.organization['name'] %}
-{% set org_link = h.url_for(controller='organization', action='read', id=pkg.owner_org) %}
-{% set col_title = pkg.title %}
-{% set col_name = h.get_extras_value(pkg.extras, 'collection_name') %}
-{% set col_link = h.get_collection_url(col_name) %}
-{% set thumbnail_path = h.ng_get_dataset_thumbnail_path(pkg) %}
 
 {% block pre_primary %}
   <div class="container single-column">

--- a/ckanext/nextgeoss/templates/package/read_base.html
+++ b/ckanext/nextgeoss/templates/package/read_base.html
@@ -22,4 +22,5 @@
       {% endif %}
     {% endblock %}
 
+    {{ super() }}
 {% endblock %}

--- a/ckanext/nextgeoss/templates/package/resources.html
+++ b/ckanext/nextgeoss/templates/package/resources.html
@@ -13,33 +13,7 @@
   <div class="container single-column">
     {% snippet "package/snippets/edit_tabs.html", pkg=pkg %}
     {% block package_description %}
-      <div class="dataset-detail">
-        <div class="dataset-detail-org-logo">
-          <div class="image">
-            <a href="{{ org_link }}">
-              <img src="{{ thumbnail_path }}" height= "210" width="210" alt="{{ thumbnail_path }}" />
-            </a>
-          </div>
-        </div>
-        {% if pkg.private %}
-          <span class="dataset-private label label-inverse pull-right">
-            <i class="fa fa-lock"></i>
-            {{ _('Private') }}
-          </span>
-        {% endif %}
-        <h1 class="dataset-detail-title">
-          {% block page_heading %}
-            {{ h.dataset_display_name(pkg) }}
-            {% if pkg.state.startswith('draft') %}
-              [{{ _('Draft') }}]
-            {% endif %}
-            {% if pkg.state == 'deleted' %}
-              [{{ _('Deleted') }}]
-            {% endif %}
-          {% endblock %}
-        </h1>
-        <h5 class="dataset-detail-title">{{ _('Published by ') }} <a href="{{ org_link }}">{{ org_title }}</a></h5>
-      </div>
+      {{ super() }}
     {% endblock %}
 
     <section id="dataset-resources" class="resources">

--- a/ckanext/nextgeoss/templates/package/resources.html
+++ b/ckanext/nextgeoss/templates/package/resources.html
@@ -5,9 +5,6 @@
 {% block subtitle %}{{ _('Resources') }} - {{ h.dataset_display_name(pkg) }}{% endblock %}
 
 {% set pkg = c.pkg_dict %}
-{% set org_title = pkg.organization.get('title') or pkg.organization['name'] %}
-{% set org_link = h.url_for(controller='organization', action='read', id=pkg.owner_org) %}
-{% set thumbnail_path = h.ng_get_dataset_thumbnail_path(pkg) %}
 
 {% block pre_primary %}
   <div class="container single-column">

--- a/ckanext/nextgeoss/templates/package/snippets/additional_info.html
+++ b/ckanext/nextgeoss/templates/package/snippets/additional_info.html
@@ -45,6 +45,18 @@
           </tr>
         {% endif %}
 
+        {% block extras scoped %}
+          {% set exclude = h.ng_extras_to_exclude() %}
+          {% set subs = h.ng_extra_names() %}
+          {% for extra in h.sorted_extras(pkg_dict.extras, subs=subs, exclude=exclude) %}
+            {% set key, value = extra %}
+              <tr rel="dc:relation" resource="_:extra{{ i }}">
+                <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key) }}</th>
+                <td class="dataset-details" property="rdf:value">{{ value }}</td>
+              </tr>
+          {% endfor %}
+        {% endblock %}
+
         {% if pkg_dict.metadata_modified %}
           <tr>
             <th scope="row" class="dataset-label">{{ _("Metadata Updated on NextGEOSS Catalogue") }}</th>
@@ -62,18 +74,6 @@
             </td>
           </tr>
         {% endif %}
-
-      {% block extras scoped %}
-        {% set exclude = h.ng_extras_to_exclude() %}
-        {% set subs = h.ng_extra_names() %}
-        {% for extra in h.sorted_extras(pkg_dict.extras, subs=subs, exclude=exclude) %}
-          {% set key, value = extra %}
-            <tr rel="dc:relation" resource="_:extra{{ i }}">
-              <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key) }}</th>
-              <td class="dataset-details" property="rdf:value">{{ value }}</td>
-            </tr>
-        {% endfor %}
-      {% endblock %}
 
       {% endblock %}
     </tbody>


### PR DESCRIPTION
This PR fixes some issues in detaset details page and all the other pages that misuse the `dataset-details-title` and `dataset-details-logo` classes. 

Ideally we shouldn't reuse CSS classes like that but since we lack LESS and inheritance is not possible in CSS I went for the next best thing which was to wrap them in another thematic class (e.g. `dataset-intro`, `organization-intro`, etc.). I also refactored a bit the templates to make sure the intro is only defined in the base template.

Fixes include:
- fixed alignment for long titles
- removed the `data_extra` field in dataset details
- moved the `Metadata Updated on NextGEOSS Catalogue` at the end of the list