### PR TITLE
Fix error that appears after UI dataset creation

### DIFF
--- a/ckanext/nextgeoss/helpers.py
+++ b/ckanext/nextgeoss/helpers.py
@@ -312,6 +312,10 @@ def get_collections_count():
 
 
 def get_collection_url(collection_name):
+    '''
+        Create URL that filters the dataset according to the
+        collection_name that has been passed.
+    '''
     collection = 'collection_id:' + collection_name
 
     return "/dataset?collection_name=" + collection_name.replace(' ', '+')
@@ -449,9 +453,16 @@ def collection_information(collection_id=None):
 
 
 def get_extras_value(extras, extras_key):
+    '''
+        Return the value from extras from a given key.
+    '''
+    value = ''
+
     for extra in extras:
         if extra['key'] == extras_key:
-            return extra['value']
+            value = extra['value']
+
+    return value
 
 
 def generate_opensearch_query(params):

--- a/ckanext/nextgeoss/templates/package/base.html
+++ b/ckanext/nextgeoss/templates/package/base.html
@@ -29,7 +29,9 @@
       {% set thumbnail = h.ng_get_dataset_thumbnail_path(pkg) %}
       {% set col_title = pkg.title %}
       {% set col_name = h.get_extras_value(pkg.extras, 'collection_name') %}
-      {% set col_link = h.get_collection_url(col_name) %}
+      {% if col_name | length > 0 %}
+        {% set col_link = h.get_collection_url(col_name) %}
+      {% endif %}
       <div class="dataset-intro">
         <div class="dataset-detail-org-logo">
           <div class="image">
@@ -58,7 +60,9 @@
           {% set org_link = h.url_for(controller='organization', action='read', id=pkg.organization.name) %}
           <h5 class="dataset-detail-title">{{ _('Published by ') }} <a href="{{ org_link }}">{{ org_title }}</a></h5>
         {% endif %}
-        <h5 class="dataset-detail-title">{{ _('Part of collection ') }} <a href="{{ col_link }}">{{ col_title }}</a></h5>
+        {% if col_link is defined %}
+          <h5 class="dataset-detail-title">{{ _('Part of collection ') }} <a href="{{ col_link }}">{{ col_title }}</a></h5>
+        {% endif %}
       </div>
     {% endif %}
   {% endblock %}


### PR DESCRIPTION
After creating a dataset the user can't preview it if a collection name is not present in the datasets metadata.
The part that gave this error was 'Part of Collection', since the variable that provides a link to the filtered datasets by that collection name didn't had a value.

This PR checks if dataset has a collection name, if collection name is not present do not show Part of collection in templates.