### PR TITLE
Featured group error on homepage

### DIFF
--- a/ckanext/nextgeoss/helpers.py
+++ b/ckanext/nextgeoss/helpers.py
@@ -489,8 +489,12 @@ def generate_opensearch_query(params):
 
 
 def get_featured_groups_list():
+    '''
+        Returns a list of groups that are setup as featured_groups
+        in the configuration file.
+    '''
     parent_groups = []
-    group_list = config.get('ckan.featured_groups')
+    group_list = config.get('ckan.featured_groups').split()
 
     groups = h.get_featured_groups(count=40)
 


### PR DESCRIPTION
Fix error on homepage that appears in the Topics section, if the featured_groups list doesn't contain any of the names of the Grops (Topics) that have been created on the portal.
Also take into consideration if featured_groups is not setup in the configuration file.