### PR TITLE
Remove alt text for dataset thumbnail

### DIFF
--- a/ckanext/nextgeoss/templates/package/base.html
+++ b/ckanext/nextgeoss/templates/package/base.html
@@ -35,7 +35,7 @@
       <div class="dataset-intro">
         <div class="dataset-detail-org-logo">
           <div class="image">
-            <img src="{{ thumbnail }}" height= "210" width="210" alt="{{ pkg.name}} thumbnail" />
+            <img src="{{ thumbnail }}" height= "210" width="210"/>
           </div>
         </div>
         {% if pkg.private %}


### PR DESCRIPTION
The alt text looks awkward in general but even more so when the package name is very long. Since it doesn't seem to provide much value I thought we can just remove it and see if anyone misses it. 