### PR TITLE
Format LAI specific fields

### DIFF
--- a/ckanext/nextgeoss/helpers.py
+++ b/ckanext/nextgeoss/helpers.py
@@ -216,7 +216,12 @@ def get_extra_names():
         'resulttime': 'Result time',
         'timeinstant': 'Time instant',
         'timeposition': 'Time position',
-        'pos': 'Position'
+        'pos': 'Position',
+        'file_identifier': 'Identifier',
+        'lineage': 'Lineage',
+        'purpose': 'Purpose',
+        'legal_notice': 'Legal Notice',
+        'supplemental_information': 'Supplemental Information',
     }
 
     return new_names
@@ -250,6 +255,7 @@ def get_extras_to_exclude():
         'noa_expiration_date',
         'uuid',
         'dataset_extra',
+        'is_output',
     ]
 
     return extras_to_exclude


### PR DESCRIPTION
LAI datasets contain some fields we don't normally display. This PR ads functionality to deal with those.

Since we are yet to decide if we want to display `timerange_end` and `timerange_start`, I [added `StartTime` and `StopTime`](https://github.com/NextGeoss/nextgeoss-scripts/commit/f6f7eb855a3313f6b3c5c74a60da3238c6a85027) to the datasets metadata. This is consistent with other data sources and it gracefully avoids dealing with `timerange_end` for now (we have a separate issue for that).

Consequently, the LAI datasets now look like this:

![image](https://user-images.githubusercontent.com/8862002/60033455-e4def580-96a8-11e9-805e-4b5c29d82501.png)
