### PR TITLE
Fix layout of dataset cards

### DIFF
--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -228,7 +228,6 @@ li.dataset-item {
     box-shadow: 0px 3px 13px -2px rgb(173, 173, 173);
 }
 .dataset-heading {
-  max-width: 400px;
   text-overflow: ellipsis;
   word-wrap: break-word;
   padding-bottom: 10px;
@@ -485,6 +484,7 @@ h4.title a {
   float: right;
   clear: left;
   margin-top: 5px !important;
+  margin-left: 30px !important;
 }
 
 .dataset-item-org-logo .image img {

--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -1536,7 +1536,7 @@ table.mobile-table td.dataset-details {
 
 li.dataset-item {
   overflow: auto !important;
-  display: inline-block !important;
+  display: block !important;
 }
 
 .topic-collection h3 {

--- a/ckanext/nextgeoss/templates/snippets/package_item.html
+++ b/ckanext/nextgeoss/templates/snippets/package_item.html
@@ -2,12 +2,15 @@
 
 {% block heading %}
 
-  <div class="dataset-item-org-logo">
-    <div class="image">
-      {% set thumbnail_path = h.ng_get_dataset_thumbnail_path(package) %}
-      <img src="{{ thumbnail_path }}" height= "210" width="210" alt="{{ thumbnail_path }}" />
+  {% set thumbnail_path = h.ng_get_dataset_thumbnail_path(package) %}
+  {% if thumbnail_path %}
+    <div class="dataset-item-org-logo">
+      <div class="image">
+        {% set thumbnail_path = h.ng_get_dataset_thumbnail_path(package) %}
+        <img src="{{ thumbnail_path }}" height= "210" width="210" alt="{{ thumbnail_path }}" />
+      </div>
     </div>
-  </div>
+  {% endif %}
 
 
   <h3 class="dataset-heading">


### PR DESCRIPTION
Fixes https://github.com/NextGeoss/nextgeoss-catalogue-issues/issues/99
Fixes https://github.com/NextGeoss/nextgeoss-catalogue-issues/issues/100

This is an issue I introduced back in the days when I was working on the dataset cards. 
Because I choose the `inline-block` layout sometimes they were looking off because the cards were resizing according to the contents.

For example:

![image](https://user-images.githubusercontent.com/8862002/65042028-4a651a00-d958-11e9-8a4a-4372c0910104.png)

After this fix it looks like this:

![image](https://user-images.githubusercontent.com/8862002/65042064-5bae2680-d958-11e9-867f-96afb63dd882.png)
