### PR TITLE
Fix search icon safari

### DIFF
--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -463,6 +463,12 @@ h4.title a {
   box-shadow: 0px 3px 13px -2px rgb(173, 173, 173);
 }
 
+.fa-search {
+  float: left !important;
+  clear: left;
+  margin-bottom: 6px;
+}
+
 .fa-search:before {
   color: #168B7A;
 }

--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -328,7 +328,6 @@ h4.title a {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  margin-top: 20px;
 }
 
 .datasets-search-form-container__controls {
@@ -942,12 +941,10 @@ article.module {
 }
 
 #group-datasets-search-form {
-  margin-top: -20px;
   margin-bottom: 50px;
  }
 
  #organization-datasets-search-form {
-  margin-top: -20px;
   margin-bottom: 50px;
  }
 


### PR DESCRIPTION
Fixes https://github.com/NextGeoss/nextgeoss-catalogue-issues/issues/102

Also fixes alignment of the search bar for both the datasets page and the provider page:

![image](https://user-images.githubusercontent.com/8862002/65151406-57503f00-da26-11e9-97ef-8d2b869679de.png)

![image](https://user-images.githubusercontent.com/8862002/65151496-84045680-da26-11e9-967b-699d59a49cfa.png)
