### PR TITLE
Integrate ckanext-collections

### DIFF
--- a/ckanext/nextgeoss/plugin.py
+++ b/ckanext/nextgeoss/plugin.py
@@ -167,8 +167,8 @@ class NextgeossPlugin(plugins.SingletonPlugin):
                       action='opensearch')
             m.connect('support', '/support',
                       action='support')
-            m.connect('collections', '/collection',
-                      action='collections')
+            m.connect('collections', '/collection_list',
+                      action='collections', group_type='collection')
             m.connect('support', '/support',
                       action='support')
 

--- a/ckanext/nextgeoss/templates/collection/read.html
+++ b/ckanext/nextgeoss/templates/collection/read.html
@@ -1,0 +1,87 @@
+{% ckan_extends %}
+
+{% block pre_primary %}
+  <div class="container single-column group-org-header">
+    {{ super() }}
+    {% block package_description %}
+      <div class="organization-intro">
+        <div class="dataset-detail-org-logo">
+          <div class="image">
+            <a href="{{ org_link }}">
+              <img src="{{ c.group_dict.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}" height= "100" width="100" alt="{{ c.group_dict.title }}" />
+            </a>
+          </div>
+        </div>
+
+        <h1 class="dataset-detail-title">
+          {% block page_heading %}
+            {% set name = c.group_dict.title or c.group_dict.name %}
+            {{ name }}
+          {% endblock %}
+        </h1>
+
+        {% block package_notes %}
+          {% if c.group_dict.description %}
+            <div class="notes embedded-content dataset-notes">
+              {{ h.render_markdown(_(c.group_dict.description)) }}
+            </div>
+          {% endif %}
+        {% endblock %}
+      </div>
+    {% endblock %}
+  </div>
+{% endblock %}
+
+
+{% block content_primary_nav %}
+  {% if h.check_access('package_create', {'owner_org': c.group_dict.id}) %}
+    {% link_for _('Add Dataset'), controller='package', action='new', group=c.group_dict.id, class_='btn btn-primary', icon='plus-sign-alt' %}
+  {% endif %}
+{% endblock %}
+
+{% block page_primary_action %}
+{% endblock %}
+
+{% block primary_content_inner %}
+  {% block groups_search_form %}
+    {% set facets = {
+      'fields': c.fields_grouped,
+      'search': c.search_facets,
+      'titles': c.facet_titles,
+      'translated_fields': c.translated_fields,
+      'remove_field': c.remove_field }
+    %}
+    {% set sorting = [
+      (_('Relevance'), 'score desc, metadata_modified desc'),
+      (_('Name Ascending'), 'title_string asc'),
+      (_('Name Descending'), 'title_string desc'),
+      (_('Last Modified'), 'metadata_modified desc'),
+      (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
+    %}
+    {% snippet 'snippets/search_form.html', form_id='group-datasets-search-form', type='dataset', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, placeholder=_('Search datasets...'), show_empty=request.params, fields=c.fields %}
+  {% endblock %}
+  {% block packages_list %}
+    {% if c.page.items %}
+      {{ h.snippet('snippets/package_list.html', packages=c.page.items) }}
+    {% endif %}
+  {% endblock %}
+  {% block page_pagination %}
+    {{ c.page.pager(q=c.q) }}
+  {% endblock %}
+{% endblock %}
+
+{% block secondary_content %}
+  <div class="filters">
+    <div>
+      <div class="filters-header">
+        <i class="fa fa-lg fa-filter"></i>
+        <span class="filters-header__title">{{ _('Filters') }}</span>
+      </div>
+      {% for facet in c.facet_titles if facet != 'collection_name' %}
+        {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id':c.group_dict.id}) }}
+      {% endfor %}
+    </div>
+    <a class="close no-text hide-filters"><i class="fa-remove-sign"></i><span class="text">close</span></a>
+  </div>
+{% endblock %}
+

--- a/ckanext/nextgeoss/templates/package/collection_list.html
+++ b/ckanext/nextgeoss/templates/package/collection_list.html
@@ -1,0 +1,45 @@
+{% ckan_extends %}
+{% import 'macros/form.html' as form %}
+
+{% set pkg = c.pkg_dict %}
+
+{% block subtitle %}
+  {{ _('Collections') }} - {{ super() }}
+{% endblock %}
+
+{% block pre_primary %}
+  <div class="container single-column">
+      {% snippet "package/snippets/nav_tabs.html", pkg=pkg %}
+      {% block package_description %}
+        {{ super() }}
+      {% endblock %}
+      <section class="additional-info">
+        <h3><i class="fa fa-info-circle"></i> {{ _('Collections') }}</h3>
+      </section>
+  </div>
+
+  {% if c.collection_dropdown %}
+    <form class="add-to-group" method="post">
+      <select id="field-add_collection" name="collection_added" data-module="autocomplete">
+        {% for option in c.collection_dropdown %}
+          <option value="{{ option[0] }}"> {{ option[1] }}</option>
+        {% endfor %}
+      </select>
+      <button type="submit" class="btn btn-primary" title="{{ _('Associate this collection with this dataset') }}">{{ _('Add to collection') }}</button>
+    </form>
+  {% endif %}
+
+  {% if c.pkg_dict.groups %}
+    <form method="post">
+      {% snippet 'collection/snippets/collection_list.html', groups=c.pkg_dict.groups %}
+    </form>
+  {% else %}
+    <p class="empty">{{ _('There are no collections associated with this dataset') }}</p>
+  {% endif %}
+{% endblock %}
+
+{% block primary_content_inner %}
+{% endblock %}
+
+{% block secondary %}
+{% endblock %}

--- a/ckanext/nextgeoss/templates/package/snippets/nav_tabs.html
+++ b/ckanext/nextgeoss/templates/package/snippets/nav_tabs.html
@@ -3,6 +3,7 @@
     {% block content_primary_nav %}
       {{ h.build_nav_icon('dataset_read', _('Dataset'), id=pkg.name) }}
       {{ h.build_nav_icon('dataset_groups', _('Topics'), id=pkg.name) }}
+      {{ h.build_nav_icon('dataset_collections', _('Collections'), id=pkg.name) }}
       {{ h.build_nav_icon('dataset_activity', _('Activity Stream'), id=pkg.name) }}
       {% if self.content_action() | trim %}
         <div class="content-action-button">

--- a/ckanext/nextgeoss/templates/snippets/search_result_text.html
+++ b/ckanext/nextgeoss/templates/snippets/search_result_text.html
@@ -28,6 +28,12 @@ Example:
   {% set text_query_none = _('No data providers found for "{query}"') %}
   {% set text_no_query = ungettext('{number} data provider found', '{number} data providers found', count) %}
   {% set text_no_query_none = _('No data providers found') %}
+
+{% elif type == 'collection' %}
+  {% set text_query = ungettext('{number} data collection found for "{query}"', '{number} data collections found for "{query}"', count) %}
+  {% set text_query_none = _('No data collections found for "{query}"') %}
+  {% set text_no_query = ungettext('{number} data collection found', '{number} data collections found', count) %}
+  {% set text_no_query_none = _('No data collections found') %}
 {%- endif -%}
 
 {% if query %}


### PR DESCRIPTION
Fixes https://github.com/NextGeoss/nextgeoss-catalogue-issues/issues/124

Integrates https://github.com/NextGeoss/ckanext-collections into the NG theme.
Main changes:

The manual collections list was moved from `/collection` to `/collection_list`. 
On `/collection` now have the collections index which looks like:
![image](https://user-images.githubusercontent.com/8862002/65438198-5dc72800-de25-11e9-87c2-9bb719f128d1.png)
The `Data collections` link in the navbar still points to the manually defined collections 


The collections details page now looks like this:
![image](https://user-images.githubusercontent.com/8862002/65438380-ab439500-de25-11e9-973b-b1fcd414e950.png)
I left all the facets there because that's how we had them before too (the whole list of datasets filtered by the given collections). We can always remove more of them.
For now I removed only the `Data collections` facet because we already are on a collection's page.

Finally the dataset page now looks like this:
![image](https://user-images.githubusercontent.com/8862002/65438649-2442ec80-de26-11e9-9dae-e2f886d2a040.png)
And the `Collection` tab shows all the the collections the dataset is part of:
![image](https://user-images.githubusercontent.com/8862002/65438703-3de43400-de26-11e9-99aa-a79e5acc9a67.png)
