### PR TITLE
Fix dataset header work-wrap in Safari and Firefox

### DIFF
--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -228,11 +228,11 @@ li.dataset-item {
     box-shadow: 0px 3px 13px -2px rgb(173, 173, 173);
 }
 .dataset-heading {
-  text-overflow: ellipsis;
-  word-wrap: break-word;
+  overflow: auto;
   padding-bottom: 10px;
 }
 .dataset-heading a {
+    word-break: break-all;
     color: #168B7A;
     font-size: 1.5em;
     font-weight: 400;


### PR DESCRIPTION
Fixes https://github.com/NextGeoss/nextgeoss-catalogue-issues/issues/167

Chrome:

https://github.com/NextGeoss/nextgeoss-catalogue-issues/issues/167

Firefox:

![image](https://user-images.githubusercontent.com/8862002/67210008-a66c0400-f418-11e9-998c-45c039c839a3.png)

Safari:

![image](https://user-images.githubusercontent.com/8862002/67210029-b08e0280-f418-11e9-8c84-f525ec3a2991.png)
