### PR TITLE
Make provider logos similar in size

### DIFF
--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -895,8 +895,17 @@ section.dataset-map-section {
   text-align: center;
 }
 
+.media-image-wrapper {
+  height: 180px;
+  width: 220px;
+}
+
 .media-item img {
   padding: 10px;
+  max-height: 180px;
+  max-width: 200px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .media-item p {
@@ -906,7 +915,6 @@ section.dataset-map-section {
 
 .media-grid {
   margin: 0px;
-  padding-left: 20px;
   background: none;
   border: none;
 }

--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -902,8 +902,8 @@ section.dataset-map-section {
 
 .media-item img {
   padding: 10px;
-  max-height: 180px;
-  max-width: 200px;
+  max-height: 100%;
+  max-width: 100%;
   margin-left: auto;
   margin-right: auto;
 }

--- a/ckanext/nextgeoss/templates/organization/snippets/organization_item.html
+++ b/ckanext/nextgeoss/templates/organization/snippets/organization_item.html
@@ -1,0 +1,54 @@
+{#
+    Renders a media item for a organization. This should be used in a list.
+
+    organization - A organization dict.
+
+    Example:
+
+        <ul class="media-grid">
+          {% for organization in organizations %}
+            {% snippet "organization/snippets/organization_item.html", organization=organization %}
+          {% endfor %}
+        </ul>
+    #}
+    {% set url = h.url_for(controller=organization.type, action='read', id=organization.name) %}
+
+    {% block item %}
+    <li class="media-item">
+      {% block item_inner %}
+        <div class="media-image-wrapper">
+            {% block image %}
+                <img src="{{ organization.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}" alt="{{ organization.name }}" class="img-responsive media-image">
+            {% endblock %}
+        </div>
+      {% block title %}
+        <h3 class="media-heading">{{ organization.display_name }}</h3>
+      {% endblock %}
+      {% block description %}
+        {% if organization.description %}
+          <p>{{ h.markdown_extract(organization.description, extract_length=80) }}</p>
+        {% endif %}
+      {% endblock %}
+      {% block datasets %}
+        {% if organization.package_count %}
+          <strong class="count">{{ ungettext('{num} Dataset', '{num} Datasets', organization.package_count).format(num=organization.package_count) }}</strong>
+        {% else %}
+          <span class="count">{{ _('0 Datasets') }}</span>
+        {% endif %}
+      {% endblock %}
+      {% block capacity %}
+        {% if show_capacity and organization.capacity %}
+        <p><span class="label label-default">{{ h.roles_translated().get(organization.capacity, organization.capacity) }}</span></p>
+        {% endif %}
+      {% endblock %}
+      {% block link %}
+      <a href="{{ url }}" title="{{ _('View {organization_name}').format(organization_name=organization.display_name) }}" class="media-view">
+        <span>{{ _('View {organization_name}').format(organization_name=organization.display_name) }}</span>
+      </a>
+      {% endblock %}
+      {% endblock %}
+    </li>
+    {% endblock %}
+    {% if position is divisibleby 3 %}
+      <li class="clearfix js-hide"></li>
+    {% endif %}


### PR DESCRIPTION
Fixes: https://github.com/NextGeoss/nextgeoss-catalogue-issues/issues/198

Provider logos are all very different and it's hard to display them in a way that suits all. Using a fixed height and width for all makes some of them look off.

That's why I created this div that confines them so that those small ones can keep being small and the big ones can be confined within the boundaries of the div.
This is how they look like after these changes

![image](https://user-images.githubusercontent.com/8862002/68306934-b9cece80-00aa-11ea-8ce2-d882806b21ac.png)

