### PR TITLE
Fix pagination display for providers and datasets

### DIFF
--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -434,6 +434,16 @@ h4.title a {
   margin-top: 20px !important;
 }
 
+.pagination {
+  display: block;
+  margin-top: 40px;
+}
+
+.pagination-left {
+  display: inline-block !important;
+  margin-left: 10px;
+}
+
 .datasets-page .module-content {
   padding-right: 0;
 }

--- a/ckanext/nextgeoss/templates/package/search.html
+++ b/ckanext/nextgeoss/templates/package/search.html
@@ -159,7 +159,9 @@
     </div>
 
     {% block page_pagination %}
-      {{ c.page.pager(q=c.q) }}
+      <div class="pagination-left">
+        {{ c.page.pager(q=c.q) }}
+      </div>
     {% endblock %}
   </section>
 


### PR DESCRIPTION
Fixes: https://github.com/NextGeoss/nextgeoss-catalogue-issues/issues/196

I moved the pagination for providers in the center:

![image](https://user-images.githubusercontent.com/8862002/68314457-7b3f1100-00b6-11ea-80ca-8989cb5b83a0.png)

and the pagination for datasets to align with the other elements on the page:

![image](https://user-images.githubusercontent.com/8862002/68314582-b17c9080-00b6-11ea-8bd6-be5751f94293.png)


