### PR TITLE
Record event on resource download button

### DIFF
--- a/ckanext/nextgeoss/templates/package/snippets/resource_item.html
+++ b/ckanext/nextgeoss/templates/package/snippets/resource_item.html
@@ -33,7 +33,7 @@
           {% set button_label = _('More info') %}
         {% endif %}
         <a href="{{ url }}" class="btn btn-primary btn-left"><i class="fa fa-info-circle"></i> {{ button_label }}</a>
-        <a href="{{ res.url }}"  class="btn btn-primary"><i class="fa fa-download"></i> {{ _('Download') }}</a>
+        <a href="{{ res.url }}"  class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}"><i class="fa fa-download"></i> {{ _('Download') }}</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
We record the download event on resource "Access data" button but not on the "Download" button resource cards:

![image](https://user-images.githubusercontent.com/8862002/69792466-fc298e00-11c6-11ea-9027-6ea16b7a60db.png)

This PR fixes that so that all resource downloads are recorded. 