### PR TITLE
Add manage button for topics

### DIFF
--- a/ckanext/nextgeoss/templates/group/read_base_primary.html
+++ b/ckanext/nextgeoss/templates/group/read_base_primary.html
@@ -7,6 +7,12 @@
   <li class="active">{% link_for c.group_dict.display_name|truncate(35), controller='group', action='read', id=c.group_dict.name %}</li>
 {% endblock %}
 
+{% block content_action %}
+{% if h.check_access('group_update', {'id': c.group_dict.id}) %}
+{% link_for _('Manage'), controller='group', action='edit', id=c.group_dict.name, class_='btn btn-default btn-right', style='float:right', icon='wrench' %}
+{% endif %}
+{% endblock %}
+
 {% block pre_primary %}
   {% set group = c.group_dict %}
     <div class="container single-column group-org-header" xmlns="http://www.w3.org/1999/html">


### PR DESCRIPTION
For child topics it looks like this:

![image](https://user-images.githubusercontent.com/8862002/69968847-949f7580-151b-11ea-8b16-e091e44bcbe8.png)

For parent topics it looks like this:

![image](https://user-images.githubusercontent.com/8862002/69968877-a5e88200-151b-11ea-9992-713c97deae3c.png)

For parent topics it looks a bit awkward but at least it follows the convention of being in the bottom right. It will anyway be used only by us internally so I think it's fine.

Complemented by https://github.com/NextGeoss/ckanext-grouphierarchy/pull/13 