### PR TITLE
Fix provider search term

### DIFF
--- a/ckanext/nextgeoss/templates/organization/index.html
+++ b/ckanext/nextgeoss/templates/organization/index.html
@@ -30,7 +30,7 @@
       {% endif %}
 
       {% block organizations_search_form %}
-        {% snippet 'snippets/search_form.html', form_id='organization-search-form', type='organization', query=q, sorting_selected=sort_by_selected, count=c.page.item_count, placeholder=_('Search organizations...'), show_empty=request.params, no_bottom_border=true if c.page.items, sorting = [(_('Name Ascending'), 'title asc'), (_('Name Descending'), 'title desc')] %}
+        {% snippet 'snippets/search_form.html', form_id='organization-search-form', type='organization', query=c.q, sorting_selected=sort_by_selected, count=c.page.item_count, placeholder=_('Search organizations...'), show_empty=request.params, no_bottom_border=true if c.page.items, sorting = [(_('Name Ascending'), 'title asc'), (_('Name Descending'), 'title desc')] %}
       {% endblock %}
       {% block organizations_list %}
         {% if c.page.items or request.params %}


### PR DESCRIPTION
Fixes https://github.com/NextGeoss/nextgeoss-catalogue-issues/issues/249

The query terms is kept is the search box and displayed next to the count:

![image](https://user-images.githubusercontent.com/8862002/71987844-37d85e80-322f-11ea-8ad4-966f49732167.png)
