### PR TITLE
Resize image to make room for provider name

### DIFF
--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -901,16 +901,24 @@ section.dataset-map-section {
 }
 
 .media-item {
-  width: 250px;
+  width: 260px;
+  height: 380px;
+  text-align: center;
+}
+
+.media-body {
+  width: 220px;
+  height: 160px;
   text-align: center;
 }
 
 .media-image-wrapper {
   height: 180px;
-  width: 220px;
+  display: flex;
 }
 
 .media-item img {
+  object-fit: scale-down;
   padding: 10px;
   max-height: 100%;
   max-width: 100%;

--- a/ckanext/nextgeoss/templates/organization/snippets/organization_item.html
+++ b/ckanext/nextgeoss/templates/organization/snippets/organization_item.html
@@ -21,31 +21,33 @@
                 <img src="{{ organization.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}" alt="{{ organization.name }}" class="img-responsive media-image">
             {% endblock %}
         </div>
-      {% block title %}
-        <h3 class="media-heading">{{ organization.display_name }}</h3>
-      {% endblock %}
-      {% block description %}
-        {% if organization.description %}
-          <p>{{ h.markdown_extract(organization.description, extract_length=80) }}</p>
-        {% endif %}
-      {% endblock %}
-      {% block datasets %}
-        {% if organization.package_count %}
-          <strong class="count">{{ ungettext('{num} Dataset', '{num} Datasets', organization.package_count).format(num=organization.package_count) }}</strong>
-        {% else %}
-          <span class="count">{{ _('0 Datasets') }}</span>
-        {% endif %}
-      {% endblock %}
-      {% block capacity %}
-        {% if show_capacity and organization.capacity %}
-        <p><span class="label label-default">{{ h.roles_translated().get(organization.capacity, organization.capacity) }}</span></p>
-        {% endif %}
-      {% endblock %}
-      {% block link %}
-      <a href="{{ url }}" title="{{ _('View {organization_name}').format(organization_name=organization.display_name) }}" class="media-view">
-        <span>{{ _('View {organization_name}').format(organization_name=organization.display_name) }}</span>
-      </a>
-      {% endblock %}
+        <div class="media-body">
+        {% block title %}
+          <h3 class="media-heading">{{ organization.display_name }}</h3>
+        {% endblock %}
+        {% block description %}
+          {% if organization.description %}
+            <p>{{ h.markdown_extract(organization.description, extract_length=80) }}</p>
+          {% endif %}
+        {% endblock %}
+        {% block datasets %}
+          {% if organization.package_count %}
+            <strong class="count">{{ ungettext('{num} Dataset', '{num} Datasets', organization.package_count).format(num=organization.package_count) }}</strong>
+          {% else %}
+            <span class="count">{{ _('0 Datasets') }}</span>
+          {% endif %}
+        {% endblock %}
+        {% block capacity %}
+          {% if show_capacity and organization.capacity %}
+          <p><span class="label label-default">{{ h.roles_translated().get(organization.capacity, organization.capacity) }}</span></p>
+          {% endif %}
+        {% endblock %}
+        {% block link %}
+        <a href="{{ url }}" title="{{ _('View {organization_name}').format(organization_name=organization.display_name) }}" class="media-view">
+          <span>{{ _('View {organization_name}').format(organization_name=organization.display_name) }}</span>
+        </a>
+        {% endblock %}
+        </div>
       {% endblock %}
     </li>
     {% endblock %}


### PR DESCRIPTION
Fixes https://github.com/NextGeoss/nextgeoss-catalogue-issues/issues/198

This PR adds functionality to allow the provider logos to resize gracefully in order to make room for longer provider names. 

The other changes were necessary to harmonize the looks of those with shorter names  so that they all look reasonably good while having the same box size.

The end result looks like this:

![image](https://user-images.githubusercontent.com/8862002/72167720-faf59e80-33cb-11ea-99e7-d3ee5423c5ee.png)
