### PR TITLE
Fix recording of resource downloads in Google Analytics

### DIFF
--- a/ckanext/nextgeoss/templates/package/resource_read.html
+++ b/ckanext/nextgeoss/templates/package/resource_read.html
@@ -56,7 +56,7 @@
           {% block resource_read_url %}
             {% set url_explanation = _('URL to access resource at source:')%}
             {% if res.url and h.is_url(res.url) %}
-              <p>{{ url_explanation }} <a href="{{ res.url }}" title="{{ res.url }}" class="resource-url-analytics">{{ res.url }}</a></p>
+              <p>{{ url_explanation }} <a href="{{ res.url }}" title="{{ res.url }}" class="resource-url-analytics resource-type-{{ res.resource_type }}">{{ res.url }}</a></p>
             {% elif res.url %}
               <p>{{ url_explanation }} {{ res.url }}</p>
             {% else %}

--- a/ckanext/nextgeoss/templates/package/snippets/resource_item.html
+++ b/ckanext/nextgeoss/templates/package/snippets/resource_item.html
@@ -33,7 +33,7 @@
           {% set button_label = _('More info') %}
         {% endif %}
         <a href="{{ url }}" class="btn btn-primary btn-left"><i class="fa fa-info-circle"></i> {{ button_label }}</a>
-        <a href="{{ res.url }}"  class="btn btn-primary"><i class="fa fa-download"></i> {{ _('Download') }}</a>
+        <a href="{{ res.url }}"  class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}"><i class="fa fa-download"></i> {{ _('Download') }}</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Resource downloads were not properly recorded and accounted for in Google Analytics because they were missing some functionality. This PR attempts to fix that. 