### PR TITLE
Properly display provider order-by box in all browsers

### DIFF
--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -1243,6 +1243,9 @@ button.btn.btn-navbar {
   }
 }
 
+.search-form .control-order-by select {
+  height: 100% !important;
+}
 
 .atlwdg-trigger.atlwdg-TOP {
   left: 0px !important;


### PR DESCRIPTION
Fixes https://github.com/NextGeoss/nextgeoss-catalogue-issues/issues/252.

Firefox:

![image](https://user-images.githubusercontent.com/8862002/74643058-66255400-5174-11ea-9fec-d05d1f3a3d0b.png)

Safari:

![image](https://user-images.githubusercontent.com/8862002/74643082-70475280-5174-11ea-9416-4ba5dd3ca5b3.png)


Chrome:
![image](https://user-images.githubusercontent.com/8862002/74643028-5c035580-5174-11ea-9636-54672954822e.png)
