### PR TITLE
Remove StartTime and StopTime

### DIFF
--- a/ckanext/nextgeoss/helpers.py
+++ b/ckanext/nextgeoss/helpers.py
@@ -139,8 +139,6 @@ def get_extra_names():
         'InstrumentName': 'Instrument Name',
         'OrbitDirection': 'Orbit Direction',
         'ProductType': 'Product Type',
-        'StartTime': 'Start Time',
-        'StopTime': 'Stop Time',
         'uuid': 'UUID',
         'beginposition': 'Sensing start',
         'cloudcoverpercentage': 'Cloud coverage percentage',


### PR DESCRIPTION
Removing mentions of  `StartTime` and `StopTime` from the code. 

Fixes https://github.com/NextGeoss/nextgeoss-catalogue-issues/issues/283