### PR TITLE
Fix alignment of elements on the page

### DIFF
--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -960,6 +960,11 @@ section.dataset-map-section {
 
 .module-content:first-child {
   padding-top: 0px;
+  padding-right: 0px !important;
+}
+
+#dataset-search-form {
+ margin-left: -20px !important;
 }
 
 article.module {

--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -314,7 +314,7 @@ h4.title a {
 
 #dataset-map-attribution {
   background-color: #D7EDEC;
-  margin: 0px !important;
+  margin: 0px 10px !important;
 }
 
 #dataset-map .module-heading {

--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -959,7 +959,6 @@ section.dataset-map-section {
 
 .module-content:first-child {
   padding-top: 0px;
-  padding-right: 0px !important;
 }
 
 article.module {
@@ -1220,6 +1219,13 @@ button.btn.btn-navbar {
   }
   .dataset-detail-org-logo {
     width: 60px;
+  }
+}
+
+@media (min-width: 768px) {
+  .span9 div.module-content {
+      padding-left: 10px;
+      padding-right:  0px !important;
   }
 }
 

--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -1542,6 +1542,7 @@ table.mobile-table td.dataset-details {
 
 #collection-list {
   list-style: none;
+  margin-left: 0px !important;
 }
 
 #collection-list li{

--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -292,7 +292,7 @@ h4.title a {
   margin-top: 15px;
   margin-bottom: 30px;
   padding-left: 10px;
-  padding-right: 10px;
+  padding-right: 15px;
 }
 .container .toolbar {
   margin-left: -15px;

--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -336,7 +336,6 @@ h4.title a {
 
 .datasets-search-form-container__controls .search-input {
   width: 400px;
-  margin-left: 20px;
 }
 
 .datasets-search-form-container__controls .search {
@@ -961,10 +960,6 @@ section.dataset-map-section {
 .module-content:first-child {
   padding-top: 0px;
   padding-right: 0px !important;
-}
-
-#dataset-search-form {
- margin-left: -20px !important;
 }
 
 article.module {

--- a/ckanext/nextgeoss/templates/package/search.html
+++ b/ckanext/nextgeoss/templates/package/search.html
@@ -129,7 +129,7 @@
 
 {% block primary_content %}
   <section class="module">
-    <div class="module-content">
+    <div class="datasets-page module-content">
       {% block form %}
         {% set facets = {
           'fields': c.fields_grouped,

--- a/ckanext/nextgeoss/templates/package/search.html
+++ b/ckanext/nextgeoss/templates/package/search.html
@@ -117,7 +117,7 @@
 
   <a class="show-filters btn">{{ _('Filter Results') }}</a></br>
 
-  <a href="{{ h.generate_opensearch_query(request.params) }}" class="action btn btn-primary" style="right: 20px; margin-bottom: 10px;">
+  <a href="{{ h.generate_opensearch_query(request.params) }}" class="action btn btn-primary" style="right: 20px; margin-bottom: 10px; margin-left: -10px;">
     {{ _('OpenSearch matching query') }}
   </a>
 


### PR DESCRIPTION
Fixes https://github.com/NextGeoss/nextgeoss-catalogue-issues/issues/388 and 
https://github.com/NextGeoss/nextgeoss-catalogue-issues/issues/393.

Changes:

On Home page `View all thematic Areas` button slighly moved to the left 

![image](https://user-images.githubusercontent.com/8862002/76222163-7e8c0a00-621a-11ea-8dec-0ad86938d352.png)


On Collections page, equal margin on both sides:

![image](https://user-images.githubusercontent.com/8862002/76222227-9794bb00-621a-11ea-8f69-9b76456f6f9a.png)

On Datasets page aligning buttons and the other elements on the page for a cleaner look:

![image](https://user-images.githubusercontent.com/8862002/76222309-b8f5a700-621a-11ea-944c-b3024462ffbb.png)

On Data Providers page equal margin on both sides:

![image](https://user-images.githubusercontent.com/8862002/76222369-cd39a400-621a-11ea-9854-eaa75b2eef53.png)
