### PR TITLE
Fixes to the resource admin pages

### DIFF
--- a/ckanext/nextgeoss/public/nextgeoss.css
+++ b/ckanext/nextgeoss/public/nextgeoss.css
@@ -614,6 +614,11 @@ h5.dataset-detail-title {
     margin-bottom: 50px;
 }
 
+.edit-resource-info {
+  border-bottom: 1px solid #292929;
+  margin-bottom: 50px;
+}
+
 .social h3 {
   border-bottom: 1px solid #292929;
 }

--- a/ckanext/nextgeoss/templates/package/edit_base.html
+++ b/ckanext/nextgeoss/templates/package/edit_base.html
@@ -12,15 +12,6 @@
   {% endif %}
 {% endblock %}
 
-{% block content_action %}
-  {% link_for _('View dataset'), controller='package', action='read', id=pkg.name, class_='btn', icon='eye-open' %}
-{% endblock %}
-
-{% block content_primary_nav %}
-  {{ h.build_nav_icon('dataset_edit', _('Edit metadata'), id=pkg.name) }}
-  {{ h.build_nav_icon('dataset_resources', _('Resources'), id=pkg.name) }}
-{% endblock %}
-
 {% block secondary_content %}
   {% snippet 'package/snippets/info.html', pkg=pkg, hide_follow_button=true %}
 {% endblock %}

--- a/ckanext/nextgeoss/templates/package/resource_edit_base.html
+++ b/ckanext/nextgeoss/templates/package/resource_edit_base.html
@@ -1,0 +1,41 @@
+{% extends "package/base.html" %}
+
+{% set logged_in = true if c.userobj else false %}
+{% set res = c.resource %}
+
+{% block breadcrumb_content_selected %}{% endblock %}
+
+{% block breadcrumb_content %}
+  {{ super() }}
+  {% if res %}
+    <li>{% link_for h.resource_display_name(res)|truncate(30), controller='package', action='resource_read', id=pkg.name, resource_id=res.id %}</li>
+    <li{% block breadcrumb_edit_selected %} class="active"{% endblock %}><a href="">{{ _('Edit') }}</a></li>
+  {% endif %}
+{% endblock %}
+
+{% block content_action %}
+  {% link_for _('All resources'), controller='package', action='resources', id=pkg.name, class_='btn', icon='arrow-left' %}
+  {% if res %}
+    {% link_for _('View resource'), controller='package', action='resource_read', id=pkg.name, resource_id=res.id, class_='btn', icon='eye' %}
+  {% endif %}
+{% endblock %}
+
+{% block content_primary_nav %}
+  {{ h.build_nav_icon('resource_edit', _('Edit resource'), id=pkg.name, resource_id=res.id) }}
+  {% block inner_primary_nav %}{% endblock %}
+  {{ h.build_nav_icon('views', _('Views'), id=pkg.name, resource_id=res.id) }}
+{% endblock %}
+
+{% block primary_content_inner %}
+  <h3 class="edit-resource-info"><i class="fa fa-info-circle" style="margin-right: 5px;"></i>{% block form_title %}{{ _('Edit resource') }}{% endblock %}</h3>
+  {% block form %}{% endblock %}
+{% endblock %}
+
+{% block secondary_content %}
+  {% snippet 'package/snippets/resource_info.html', res=res %}
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {% resource 'vendor/fileupload' %}
+{% endblock %}

--- a/ckanext/nextgeoss/templates/package/resource_read.html
+++ b/ckanext/nextgeoss/templates/package/resource_read.html
@@ -132,5 +132,8 @@
 
 {% endblock %}
 
+{% block primary %}
+{% endblock %}
+
 {% block secondary %}
 {% endblock %}


### PR DESCRIPTION
Fixes 
https://github.com/NextGeoss/nextgeoss-catalogue-issues/issues/251

This PR adds a few fixes to the resource admin pages:

Removed the redundant edit dataset tabs:

![image](https://user-images.githubusercontent.com/8862002/76968830-d5d05f80-6929-11ea-9e60-6d48570aad05.png)

Removed the redundant resource manage tabs:

<img width="1260" alt="Screenshot 2020-03-18 at 14 21 19" src="https://user-images.githubusercontent.com/8862002/76968892-ec76b680-6929-11ea-99c5-6be4904a1216.png">

Made the title visible in the resource edit page and similar in look with the one we have on dataset edit page:

<img width="1659" alt="Screenshot 2020-03-18 at 15 00 54" src="https://user-images.githubusercontent.com/8862002/76968994-162fdd80-692a-11ea-94cd-d8ffa54a1bea.png">

