### PR TITLE
Integrate Noa linker service

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ links to the resources for a specific Dataset.
 For the NOA linker provider you will need the follwoing setup in your .ini file:
 
 ```
-ckanext.nextgeoss.noa_linker_active = True/False
+ckanext.nextgeoss.noa_linker_active = True/False (default False)
 ckanext.nextgeoss.linker_service_base_url = link_to_noa_linker_service
 ckanext.nextgeoss.linker_service_user = user
 ckanext.nextgeoss.linker_service_password = pass

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ All of the changes and customizations mentioned above are contained in the NextG
 
 The NiMMbus functionality can be broken out into a separate plugin.
 
+This extension also adds an integration with the NOA Linker Service. Which allows us to query and get additional
+links to the resources for a specific Dataset.
+For the NOA linker provider you will need the follwoing setup in your .ini file:
+
+```
+ckanext.nextgeoss.linker_service_base_url = link_to_noa_linker_service
+ckanext.nextgeoss.linker_service_user = user
+ckanext.nextgeoss.linker_service_password = pass
+```
+
 ## Development Installation
 
 To install ckanext-nextgeoss for development, activate your CKAN virtualenv and

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ links to the resources for a specific Dataset.
 For the NOA linker provider you will need the follwoing setup in your .ini file:
 
 ```
+ckanext.nextgeoss.noa_linker_active = True/False
 ckanext.nextgeoss.linker_service_base_url = link_to_noa_linker_service
 ckanext.nextgeoss.linker_service_user = user
 ckanext.nextgeoss.linker_service_password = pass

--- a/ckanext/nextgeoss/helpers.py
+++ b/ckanext/nextgeoss/helpers.py
@@ -1,4 +1,6 @@
 from ckan.common import config
+from concurrent.futures import as_completed
+from requests_futures.sessions import FuturesSession
 import ckan.logic as logic
 import ckan.plugins as p
 import ckan.lib.helpers as h
@@ -9,6 +11,7 @@ import datetime
 import requests
 import json
 import re
+import urlparse
 from ckan.lib.helpers import url_for_static
 from ckanext.opensearch import config as opensearch_config
 
@@ -19,7 +22,47 @@ def get_jira_script():
     return jira_script
 
 
-def get_linker_service_resources(dataset_name, testing=False):
+def get_noa_linker_resources(packages):
+    noa_url = config.get('ckanext.nextgeoss.linker_service_base_url')
+    noa_user = config.get('ckanext.nextgeoss.linker_service_user')
+    noa_password = config.get('ckanext.nextgeoss.linker_service_password')
+    noa_package_resources = {}
+
+    if noa_url:
+        with FuturesSession(max_workers=25) as session:
+            urls = ["{0}/search?q={1}&format=json".format(noa_url, package['name']) for package in packages]
+            futures = [session.get(url, auth=(noa_user, noa_password), timeout=2) for url in urls]
+            for future in as_completed(futures):
+                response = future.result()
+                package_query = urlparse.urlparse(response.request.url).query
+                package_name = urlparse.parse_qs(package_query)['q'][0]
+                package_resources = []
+                try:
+                    response_body = response.json()
+                    response.raise_for_status()
+                    # Sometimes `entry` is a dict, sometimes an array, depending on n.o. results
+                    results = response_body['feed'].get('entry', [])
+                except requests.exceptions.RequestException as e:
+                    log.error('Error querying the Noa Linker Service: %s', e.message)
+                    results = []
+
+                if isinstance(results, dict):
+                    results = [results]
+
+                for entry in results:
+                    sources = entry.get('sources', {}).get('link')
+                    if isinstance(sources, dict):
+                        sources = [sources]
+                    for source in sources:
+                        package_resources.append(source['href'])
+                noa_package_resources[package_name] = package_resources
+    else:
+        log.info('Configuration for Linker Service is missing.')
+
+    return noa_package_resources
+
+
+def get_noa_linker_package_resources(dataset_name, testing=False):
     """
     Retrieve the sources of the dataset from the Noa Linker Service.
     """
@@ -28,11 +71,9 @@ def get_linker_service_resources(dataset_name, testing=False):
     noa_user = config.get('ckanext.nextgeoss.linker_service_user')
     noa_password = config.get('ckanext.nextgeoss.linker_service_password')
     resources = []
-    print('QUERY_URL {0}'.format(noa_url))
 
     if noa_url or testing:
         query_url = "{0}/search?q={1}&format=json".format(noa_url, dataset_name)
-        print('QUERY_URL {0}'.format(query_url))
         try:
             response = requests.get(query_url, auth=(noa_user, noa_password), timeout=2)
             response.raise_for_status()

--- a/ckanext/nextgeoss/helpers.py
+++ b/ckanext/nextgeoss/helpers.py
@@ -19,7 +19,7 @@ def get_jira_script():
     return jira_script
 
 
-def get_linker_service_resources(dataset_name):
+def get_linker_service_resources(dataset_name, testing=False):
     """
     Retrieve the sources of the dataset from the Noa Linker Service.
     """
@@ -28,12 +28,13 @@ def get_linker_service_resources(dataset_name):
     noa_user = config.get('ckanext.nextgeoss.linker_service_user')
     noa_password = config.get('ckanext.nextgeoss.linker_service_password')
     resources = []
+    print('QUERY_URL {0}'.format(noa_url))
 
-    if noa_url:
+    if noa_url or testing:
         query_url = "{0}/search?q={1}&format=json".format(noa_url, dataset_name)
         print('QUERY_URL {0}'.format(query_url))
         try:
-            response = requests.get(query_url, auth=(noa_user, noa_password), timeout=0.001)
+            response = requests.get(query_url, auth=(noa_user, noa_password), timeout=1)
             response.raise_for_status()
             response_body = response.json()
             # Sometimes `entry` is a dict, sometimes an array, depending on n.o. results
@@ -50,6 +51,8 @@ def get_linker_service_resources(dataset_name):
                 sources = [sources]
             for source in sources:
                 resources.append(source['link']['href'])
+    else:
+        log.info('Configuration for Linker Service is missing.')
 
     return resources
 

--- a/ckanext/nextgeoss/helpers.py
+++ b/ckanext/nextgeoss/helpers.py
@@ -22,6 +22,69 @@ def get_jira_script():
     return jira_script
 
 
+def get_noa_linker_resources_for_package(package):
+    noa_active = config.get('ckanext.nextgeoss.noa_linker_acitve', False)
+    noa_package_resources = {}
+
+    if noa_active == str('True'):
+        noa_url = config.get('ckanext.nextgeoss.linker_service_base_url')
+        noa_user = config.get('ckanext.nextgeoss.linker_service_user')
+        noa_password = config.get('ckanext.nextgeoss.linker_service_password')
+
+        package_id = package.get('id', None)
+        package = logic.get_action('package_show')({}, {'id': package_id})
+
+
+        if noa_url:
+            # Check if the collection_id of the package is Sentinel
+            # If it is - make a call to NOA linker service
+            # if not - skip
+            new_package = []
+
+            include = check_dataset_collection_timestamp(package)
+
+            if include == True:
+                new_package.append(package)
+
+
+            with FuturesSession(max_workers=25) as session:
+                urls = ["{0}/search?q={1}&format=json".format(noa_url, package['name']) for package in new_package]
+                futures = [session.get(url, auth=(noa_user, noa_password), timeout=2) for url in urls]
+
+                for future in as_completed(futures):
+                    response = future.result()
+                    package_query = urlparse.urlparse(response.request.url).query
+                    package_name = urlparse.parse_qs(package_query)['q'][0]
+                    package_resources = []
+                    try:
+                        response_body = response.json()
+                        response.raise_for_status()
+                        # Sometimes `entry` is a dict, sometimes an array, depending on n.o. results
+                        results = response_body['feed']
+
+                    except requests.exceptions.RequestException as e:
+                        log.error('Error querying the Noa Linker Service: %s', e.message)
+                        results = []
+
+                    if isinstance(results, dict):
+                        results = [results]
+
+                    for entry in results:
+                        sources = entry.get('link', {})
+
+                        if isinstance(sources, dict):
+                            sources = [sources]
+                        for source in sources:
+                            package_resources.append(source['href'])
+
+                    noa_package_resources[package_name] = package_resources
+
+        else:
+            log.info('Configuration for Linker Service is missing.')
+
+    return noa_package_resources
+
+
 def get_noa_linker_resources(packages):
     noa_active = config.get('ckanext.nextgeoss.noa_linker_acitve', False)
     noa_package_resources = {}
@@ -36,11 +99,18 @@ def get_noa_linker_resources(packages):
             # If it is - make a call to NOA linker service
             # if not - skip
             new_package = []
-            for package in packages:
-                    include = check_dataset_collection_timestamp(package)
 
-                    if include == True:
-                        new_package.append(package)
+            if len(packages) > 1:
+                for package in packages:
+                        include = check_dataset_collection_timestamp(package)
+
+                        if include == True:
+                            new_package.append(package)
+            else:
+                include = check_dataset_collection_timestamp(packages)
+
+                if include == True:
+                    new_package.append(packages)
 
             with FuturesSession(max_workers=25) as session:
                 urls = ["{0}/search?q={1}&format=json".format(noa_url, package['name']) for package in new_package]
@@ -135,18 +205,23 @@ def check_dataset_collection_timestamp(package):
         Returns True or False
     '''
     include = False
+    extras = package.get('extras', None)
 
-    collection_id = get_extras_value(package['extras'], 'collection_id')
+    if extras is not None:
+        collection_id = get_extras_value(package['extras'], 'collection_id')
 
-    # check if the dataset is older then 3 months (92 days)
-    timerange_start = get_extras_value(package['extras'], 'timerange_start')
-    timerange_start = datetime.datetime.strptime(timerange_start, '%Y-%m-%dT%H:%M:%S.%fZ')
-    date_today = datetime.datetime.now()
+        # check if the dataset is older then 3 months (92 days)
+        timerange_start = get_extras_value(package['extras'], 'timerange_start')
+        try:
+            timerange_start = datetime.datetime.strptime(timerange_start, '%Y-%m-%dT%H:%M:%S.%fZ')
+        except:
+            timerange_start = datetime.datetime.strptime(timerange_start, '%Y-%m-%dT%H:%M:%S')
+        date_today = datetime.datetime.now()
 
-    time_between_insertion = date_today - timerange_start
+        time_between_insertion = date_today - timerange_start
 
-    if 'SENTINEL' in collection_id and time_between_insertion.days < 92:
-        include = True
+        if 'SENTINEL' in collection_id and time_between_insertion.days < 92:
+            include = True
 
     return  include
 

--- a/ckanext/nextgeoss/helpers.py
+++ b/ckanext/nextgeoss/helpers.py
@@ -34,7 +34,7 @@ def get_linker_service_resources(dataset_name, testing=False):
         query_url = "{0}/search?q={1}&format=json".format(noa_url, dataset_name)
         print('QUERY_URL {0}'.format(query_url))
         try:
-            response = requests.get(query_url, auth=(noa_user, noa_password), timeout=1)
+            response = requests.get(query_url, auth=(noa_user, noa_password), timeout=2)
             response.raise_for_status()
             response_body = response.json()
             # Sometimes `entry` is a dict, sometimes an array, depending on n.o. results
@@ -46,11 +46,11 @@ def get_linker_service_resources(dataset_name, testing=False):
             results = []
 
         for entry in results:
-            sources = entry.get('sources')
+            sources = entry.get('sources', {}).get('link')
             if isinstance(sources, dict):
                 sources = [sources]
             for source in sources:
-                resources.append(source['link']['href'])
+                resources.append(source['href'])
     else:
         log.info('Configuration for Linker Service is missing.')
 

--- a/ckanext/nextgeoss/plugin.py
+++ b/ckanext/nextgeoss/plugin.py
@@ -210,7 +210,6 @@ class NextgeossPlugin(plugins.SingletonPlugin):
 
     def harvest_facets(self, facets_dict):
         """Update the facets used on the harvest page."""
-
         facets_dict.clear()
         facets_dict['frequency']  = plugins.toolkit._('Frequency')
         facets_dict['collection_name'] = plugins.toolkit._('Data Collections')

--- a/ckanext/nextgeoss/plugin.py
+++ b/ckanext/nextgeoss/plugin.py
@@ -65,6 +65,7 @@ class NextgeossPlugin(plugins.SingletonPlugin):
              'get_topic_output_data': helpers.get_topic_output_data,
              'get_noa_linker_package_resources': helpers.get_noa_linker_package_resources,
              'get_noa_linker_resources': helpers.get_noa_linker_resources,
+             'get_noa_linker_resources_for_package': helpers.get_noa_linker_resources_for_package,
 
         }
 

--- a/ckanext/nextgeoss/plugin.py
+++ b/ckanext/nextgeoss/plugin.py
@@ -62,7 +62,8 @@ class NextgeossPlugin(plugins.SingletonPlugin):
              'get_begin_period_topics': helpers.get_begin_period_topics,
              'get_end_period_topics': helpers.get_end_period_topics,
              'get_featured_groups_list': helpers.get_featured_groups_list,
-             'get_topic_output_data': helpers.get_topic_output_data
+             'get_topic_output_data': helpers.get_topic_output_data,
+             'get_linker_service_resources': helpers.get_linker_service_resources,
         }
 
     # IRoutes

--- a/ckanext/nextgeoss/plugin.py
+++ b/ckanext/nextgeoss/plugin.py
@@ -63,7 +63,9 @@ class NextgeossPlugin(plugins.SingletonPlugin):
              'get_end_period_topics': helpers.get_end_period_topics,
              'get_featured_groups_list': helpers.get_featured_groups_list,
              'get_topic_output_data': helpers.get_topic_output_data,
-             'get_linker_service_resources': helpers.get_linker_service_resources,
+             'get_noa_linker_package_resources': helpers.get_noa_linker_package_resources,
+             'get_noa_linker_resources': helpers.get_noa_linker_resources,
+
         }
 
     # IRoutes

--- a/ckanext/nextgeoss/templates/package/read.html
+++ b/ckanext/nextgeoss/templates/package/read.html
@@ -31,12 +31,10 @@
       {% snippet "package/snippets/resources_list.html", pkg=pkg, resources=pkg.resources %}
     {% endblock %}
 
-    {% if h.get_noa_linker_package_resources(pkg.name)|length > 0 %}
     {% block noa_resources %}
-      {% set package_noa_resources = h.get_noa_linker_package_resources(pkg.name) %}
+      {% set package_noa_resources = h.get_noa_linker_package_resources(pkg) %}
       {% snippet "package/snippets/noa_resources_list.html", pkg=pkg, resources=package_noa_resources %}
     {% endblock %}
-    {% endif %}
 
     {% block package_additional_info %}
       {% snippet "package/snippets/additional_info.html", pkg_dict=pkg %}

--- a/ckanext/nextgeoss/templates/package/read.html
+++ b/ckanext/nextgeoss/templates/package/read.html
@@ -31,6 +31,13 @@
       {% snippet "package/snippets/resources_list.html", pkg=pkg, resources=pkg.resources %}
     {% endblock %}
 
+    {% if h.get_linker_service_resources(pkg.name)|length > 0 %}
+    {% block noa_resources %}
+      {% set dataset_noa_resources = h.get_linker_service_resources(pkg.name) %}
+      {% snippet "package/snippets/noa_resources_list.html", pkg=pkg, resources=dataset_noa_resources %}
+    {% endblock %}
+    {% endif %}
+
     {% block package_additional_info %}
       {% snippet "package/snippets/additional_info.html", pkg_dict=pkg %}
     {% endblock %}

--- a/ckanext/nextgeoss/templates/package/read.html
+++ b/ckanext/nextgeoss/templates/package/read.html
@@ -31,10 +31,10 @@
       {% snippet "package/snippets/resources_list.html", pkg=pkg, resources=pkg.resources %}
     {% endblock %}
 
-    {% if h.get_linker_service_resources(pkg.name)|length > 0 %}
+    {% if h.get_noa_linker_package_resources(pkg.name)|length > 0 %}
     {% block noa_resources %}
-      {% set dataset_noa_resources = h.get_linker_service_resources(pkg.name) %}
-      {% snippet "package/snippets/noa_resources_list.html", pkg=pkg, resources=dataset_noa_resources %}
+      {% set package_noa_resources = h.get_noa_linker_package_resources(pkg.name) %}
+      {% snippet "package/snippets/noa_resources_list.html", pkg=pkg, resources=package_noa_resources %}
     {% endblock %}
     {% endif %}
 

--- a/ckanext/nextgeoss/templates/package/search.html
+++ b/ckanext/nextgeoss/templates/package/search.html
@@ -162,7 +162,8 @@
         {% endif %}
       {% endblock %}
       {% block package_search_results_list %}
-        {{ h.snippet('snippets/package_list.html', packages=c.page.items) }}
+        {% set noa_packages_resources = h.get_noa_linker_resources(c.page.items) %}
+        {{ h.snippet('snippets/package_list.html', packages=c.page.items, noa_packages_resources=noa_packages_resources) }}
       {% endblock %}
     </div>
 

--- a/ckanext/nextgeoss/templates/package/snippets/noa_resource_item.html
+++ b/ckanext/nextgeoss/templates/package/snippets/noa_resource_item.html
@@ -1,0 +1,32 @@
+<div>
+  <div class="info" id="resource-box">
+    <div class="resource-box-left">
+      <div class="resource-box-file-type">
+        <div class="resource-box-icon">
+        <i class="fa fa-file-archive-o"></i>
+        </div>
+        <p class="resource-box-file-ext">{{ _('DATA') }}</p>
+      </div>
+    </div>
+
+    <div class="resource-box-right">
+      <div class="resource-box-text-area">
+        <h3>
+          <a href="{{ res }}" class="resource-box-title">Unnamed resource</a>
+        </hr>
+        </h3>
+        <p>
+          {% if res.description %}
+            {{ h.markdown_extract(h.get_translated(res, 'description'), extract_length=300) }}
+          {% else %}
+            <p class="empty">{{ _('There is no description for this resource') }}</p>
+          {% endif %}
+        </p>
+      </div>
+
+      <div class="resource-box-buttons">
+        <a href="{{ res }}"  class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}"><i class="fa fa-download"></i> {{ _('Download') }}</a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/ckanext/nextgeoss/templates/package/snippets/noa_resources_list.html
+++ b/ckanext/nextgeoss/templates/package/snippets/noa_resources_list.html
@@ -7,7 +7,7 @@
 
   Example:
 
-    {% snippet "package/snippets/resources_list.html", pkg=pkg, resources=dataset_noa_resources %}
+    {% snippet "package/snippets/resources_list.html", pkg=pkg, resources=package_noa_resources %}
 #}
 
 <h4 style="margin-top: 60px; margin-left: 10px;">{{ _('Or download resources from the Noa Linker Service:') }}</h3>

--- a/ckanext/nextgeoss/templates/package/snippets/noa_resources_list.html
+++ b/ckanext/nextgeoss/templates/package/snippets/noa_resources_list.html
@@ -1,0 +1,31 @@
+
+{#
+  Renders a list of resources with icons and view links.
+
+  resources - A list of resources to render
+  pkg - A package object that the resources belong to.
+
+  Example:
+
+    {% snippet "package/snippets/resources_list.html", pkg=pkg, resources=dataset_noa_resources %}
+#}
+
+<h4 style="margin-top: 60px; margin-left: 10px;">{{ _('Or download resources from the Noa Linker Service:') }}</h3>
+
+<section id="dataset-resources" class="resources">
+
+  {% block resource_list %}
+  {% if resources %}
+    <div class="topic-list">
+      <ul class="resource-list">
+      {% block resource_list_inner %}
+        {% for resource in resources %}
+          {% snippet 'package/snippets/noa_resource_item.html', pkg=pkg, res=resource %}
+        {% endfor %}
+      {% endblock %}
+      </ul>
+    </div>
+  {% endif %}
+  {% endblock %}
+</section>
+

--- a/ckanext/nextgeoss/templates/snippets/package_item.html
+++ b/ckanext/nextgeoss/templates/snippets/package_item.html
@@ -72,7 +72,7 @@
     </li>
   {% endfor %}
   {% if noa_resources|length > 0 %}
-  <h5>{{ _('Download resources directly from Noa:') }}</h5>
+  <h5>{{ _('Download resources from the Noa Linker Service:') }}</h5>
   {% for link in noa_resources %}
     <li>
       <a href="{{ link }}" class="label"><i class="fa fa-download"></i> DATA</a>

--- a/ckanext/nextgeoss/templates/snippets/package_item.html
+++ b/ckanext/nextgeoss/templates/snippets/package_item.html
@@ -59,6 +59,7 @@
 
 {% block resources_inner %}
   <h5>{{ _('Download resources directly from source:') }}</h5>
+  {% set noa_resources = h.get_linker_service_resources(package.name) %}
   {% for resource in package.resources %}
     {% set url = resource.url %}
     {% if resource.format %}
@@ -68,6 +69,11 @@
     {% endif %}
     <li>
       <a href="{{ url }}" class="label"><i class="fa fa-download"></i>  {{ format }}</a>
+    </li>
+  {% endfor %}
+  {% for link in noa_resources %}
+    <li>
+      <a href="{{ link }}" class="label"><i class="fa fa-download"></i>dataset</a>
     </li>
   {% endfor %}
 {% endblock %}

--- a/ckanext/nextgeoss/templates/snippets/package_item.html
+++ b/ckanext/nextgeoss/templates/snippets/package_item.html
@@ -58,7 +58,6 @@
 {% endblock %}
 
 {% block resources_inner %}
-  {% set package_noa_resources = h.get_linker_service_resources(package.name) %}
   <h5>{{ _('Download resources directly from source:') }}</h5>
   {% for resource in package.resources %}
     {% set url = resource.url %}
@@ -71,9 +70,9 @@
       <a href="{{ url }}" class="label"><i class="fa fa-download"></i>  {{ format }}</a>
     </li>
   {% endfor %}
-  {% if package_noa_resources|length > 0 %}
+  {% if noa_package_resources|length > 0 %}
   <h5>{{ _('Download resources from the Noa Linker Service:') }}</h5>
-  {% for link in package_noa_resources %}
+  {% for link in noa_package_resources %}
     <li>
       <a href="{{ link }}" class="label"><i class="fa fa-download"></i> DATA</a>
     </li>

--- a/ckanext/nextgeoss/templates/snippets/package_item.html
+++ b/ckanext/nextgeoss/templates/snippets/package_item.html
@@ -58,8 +58,8 @@
 {% endblock %}
 
 {% block resources_inner %}
-  <h5>{{ _('Download resources directly from source:') }}</h5>
   {% set noa_resources = h.get_linker_service_resources(package.name) %}
+  <h5>{{ _('Download resources directly from source:') }}</h5>
   {% for resource in package.resources %}
     {% set url = resource.url %}
     {% if resource.format %}
@@ -71,9 +71,12 @@
       <a href="{{ url }}" class="label"><i class="fa fa-download"></i>  {{ format }}</a>
     </li>
   {% endfor %}
+  {% if noa_resources|length > 0 %}
+  <h5>{{ _('Download resources directly from Noa:') }}</h5>
   {% for link in noa_resources %}
     <li>
-      <a href="{{ link }}" class="label"><i class="fa fa-download"></i>dataset</a>
+      <a href="{{ link }}" class="label"><i class="fa fa-download"></i> DATA</a>
     </li>
   {% endfor %}
+  {% endif %}
 {% endblock %}

--- a/ckanext/nextgeoss/templates/snippets/package_item.html
+++ b/ckanext/nextgeoss/templates/snippets/package_item.html
@@ -58,7 +58,7 @@
 {% endblock %}
 
 {% block resources_inner %}
-  {% set noa_resources = h.get_linker_service_resources(package.name) %}
+  {% set package_noa_resources = h.get_linker_service_resources(package.name) %}
   <h5>{{ _('Download resources directly from source:') }}</h5>
   {% for resource in package.resources %}
     {% set url = resource.url %}
@@ -71,9 +71,9 @@
       <a href="{{ url }}" class="label"><i class="fa fa-download"></i>  {{ format }}</a>
     </li>
   {% endfor %}
-  {% if noa_resources|length > 0 %}
+  {% if package_noa_resources|length > 0 %}
   <h5>{{ _('Download resources from the Noa Linker Service:') }}</h5>
-  {% for link in noa_resources %}
+  {% for link in package_noa_resources %}
     <li>
       <a href="{{ link }}" class="label"><i class="fa fa-download"></i> DATA</a>
     </li>

--- a/ckanext/nextgeoss/templates/snippets/package_list.html
+++ b/ckanext/nextgeoss/templates/snippets/package_list.html
@@ -1,0 +1,29 @@
+{#
+    Displays a list of datasets.
+
+    packages       - A list of packages to display.
+    noa_packages_resources - A list of noa resources corresponding to the package
+    list_class     - The class name for the list item.
+    item_class     - The class name to use on each item.
+    hide_resources - If true hides the resources (default: false).
+    banner         - If true displays a popular banner (default: false).
+    truncate       - The length to trucate the description to (default: 180)
+    truncate_title - The length to truncate the title to (default: 80).
+
+    Example:
+
+        {% snippet 'snippets/package_list.html', packages=c.datasets %}
+
+#}
+{% block package_list %}
+  {% if packages %}
+  <ul class="{{ list_class or 'dataset-list list-unstyled' }}">
+    {% block package_list_inner %}
+    {% for package in packages %}
+    {% set noa_package_resources = noa_packages_resources[package.name]%}
+    {% snippet 'snippets/package_item.html', package=package, item_class=item_class, hide_resources=hide_resources, banner=banner, truncate=truncate, truncate_title=truncate_title, noa_package_resources=noa_package_resources %}
+    {% endfor %}
+    {% endblock %}
+  </ul>
+  {% endif %}
+{% endblock %}

--- a/ckanext/nextgeoss/templates/snippets/package_list.html
+++ b/ckanext/nextgeoss/templates/snippets/package_list.html
@@ -21,7 +21,8 @@
     {% block package_list_inner %}
     {% for package in packages %}
     {% set noa_package_resources = noa_packages_resources[package.name]%}
-    {% snippet 'snippets/package_item.html', package=package, item_class=item_class, hide_resources=hide_resources, banner=banner, truncate=truncate, truncate_title=truncate_title, noa_package_resources=noa_package_resources %}
+    {% snippet 'snippets/package_item.html', package=package, item_class=item_class, hide_resources=hide_resources,
+      banner=banner, truncate=truncate, truncate_title=truncate_title, noa_package_resources=noa_package_resources %}
     {% endfor %}
     {% endblock %}
   </ul>

--- a/ckanext/nextgeoss/tests/test_helpers.py
+++ b/ckanext/nextgeoss/tests/test_helpers.py
@@ -7,7 +7,7 @@ import requests
 class TestHelpers(object):
 
     @mock.patch('ckanext.nextgeoss.helpers.requests.get')
-    def test_get_linker_service_resources_found(self, mock_get):   
+    def test_get_noa_linker_package_resources_found(self, mock_get):
         dataset_name = "s1a_iw_slc__1sdv_20200422t150816_20200422t150844_032242_03bac7_6dba"
         source_link = "https://sentinels.space.noa.gr/dhus/odata/v1/Products('aba3a5f3-d6cc-497c-a0ce-0d1732d6aa16')/$value"
         response = {
@@ -29,10 +29,10 @@ class TestHelpers(object):
         
         mock_get().configure_mock(status_code=200)
         mock_get().json.return_value = response
-        assert(helpers.get_linker_service_resources(dataset_name, testing=True) == [source_link])
+        assert(helpers.get_noa_linker_package_resources(dataset_name, testing=True) == [source_link])
 
     @mock.patch('ckanext.nextgeoss.helpers.requests.get')
-    def test_get_linker_service_resources_not_found(self, mock_get):   
+    def test_get_noa_linker_package_resources_not_found(self, mock_get):
         dataset_name = "s1a_iw_slc__1sdv_20200422t150816_20200422t150844_032242_03bac7_6dba"
         response = {
             "feed": {}
@@ -40,16 +40,16 @@ class TestHelpers(object):
        
         mock_get().configure_mock(status_code=200)
         mock_get().json.return_value = response
-        assert(helpers.get_linker_service_resources(dataset_name, testing=True) == [])
+        assert(helpers.get_noa_linker_package_resources(dataset_name, testing=True) == [])
 
     @mock.patch('ckanext.nextgeoss.helpers.requests.get')
-    def test_get_linker_service_resources_timeout(self, mock_get):   
+    def test_get_noa_linker_package_resources_timeout(self, mock_get):
         dataset_name = "s1a_iw_slc__1sdv_20200422t150816_20200422t150844_032242_03bac7_6dba"
         mock_get().side_effect = requests.exceptions.ReadTimeout()
-        assert(helpers.get_linker_service_resources(dataset_name, testing=True) == [])
+        assert(helpers.get_noa_linker_package_resources(dataset_name, testing=True) == [])
     
     @mock.patch('ckanext.nextgeoss.helpers.requests.get')
-    def test_get_linker_service_resources_http_error(self, mock_get):   
+    def test_get_noa_linker_package_resources_http_error(self, mock_get):
         dataset_name = "s1a_iw_slc__1sdv_20200422t150816_20200422t150844_032242_03bac7_6dba"
         mock_get().side_effect = requests.exceptions.HTTPError()
-        assert(helpers.get_linker_service_resources(dataset_name, testing=True) == [])
+        assert(helpers.get_noa_linker_package_resources(dataset_name, testing=True) == [])

--- a/ckanext/nextgeoss/tests/test_helpers.py
+++ b/ckanext/nextgeoss/tests/test_helpers.py
@@ -1,0 +1,55 @@
+"""Tests for helpers.py."""
+
+from ckanext.nextgeoss import helpers
+import mock
+import requests
+
+class TestHelpers(object):
+
+    @mock.patch('ckanext.nextgeoss.helpers.requests.get')
+    def test_get_linker_service_resources_found(self, mock_get):   
+        dataset_name = "s1a_iw_slc__1sdv_20200422t150816_20200422t150844_032242_03bac7_6dba"
+        source_link = "https://sentinels.space.noa.gr/dhus/odata/v1/Products('aba3a5f3-d6cc-497c-a0ce-0d1732d6aa16')/$value"
+        response = {
+            "feed": {
+                "entry": [
+                    {
+                        "title": "s1a_iw_slc__1sdv_20200422t150816_20200422t150844_032242_03bac7_6dba",
+                        "id": "aba3a5f3-d6cc-497c-a0ce-0d1732d6aa16",
+                        "summary": "Date: 2020-04-23T05:35:46.921Z, Instrument: SAR-C SAR, Mode: VV VH, Satellite: Sentinel-1, Size: 1.6 GB",
+                        "sources": {
+                            "link": {
+                                "href": source_link,
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+        
+        mock_get().configure_mock(status_code=200)
+        mock_get().json.return_value = response
+        assert(helpers.get_linker_service_resources(dataset_name, testing=True) == [source_link])
+
+    @mock.patch('ckanext.nextgeoss.helpers.requests.get')
+    def test_get_linker_service_resources_not_found(self, mock_get):   
+        dataset_name = "s1a_iw_slc__1sdv_20200422t150816_20200422t150844_032242_03bac7_6dba"
+        response = {
+            "feed": {}
+        }
+       
+        mock_get().configure_mock(status_code=200)
+        mock_get().json.return_value = response
+        assert(helpers.get_linker_service_resources(dataset_name, testing=True) == [])
+
+    @mock.patch('ckanext.nextgeoss.helpers.requests.get')
+    def test_get_linker_service_resources_timeout(self, mock_get):   
+        dataset_name = "s1a_iw_slc__1sdv_20200422t150816_20200422t150844_032242_03bac7_6dba"
+        mock_get().side_effect = requests.exceptions.ReadTimeout()
+        assert(helpers.get_linker_service_resources(dataset_name, testing=True) == [])
+    
+    @mock.patch('ckanext.nextgeoss.helpers.requests.get')
+    def test_get_linker_service_resources_http_error(self, mock_get):   
+        dataset_name = "s1a_iw_slc__1sdv_20200422t150816_20200422t150844_032242_03bac7_6dba"
+        mock_get().side_effect = requests.exceptions.HTTPError()
+        assert(helpers.get_linker_service_resources(dataset_name, testing=True) == [])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 shapely
+requests_futures

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 shapely
-requests_futures
+requests_futures == 0.9.9

--- a/test-core.ini
+++ b/test-core.ini
@@ -12,7 +12,7 @@ port = 5000
 
 
 [app:main]
-use = config:../ckan/test-core.ini
+use = config:../../src/ckan/test-core.ini
 # Here we hard-code the database and a flag to make default tests
 # run fast.
 ckan.plugins = nextgeoss

--- a/test.ini
+++ b/test.ini
@@ -9,7 +9,7 @@ host = 0.0.0.0
 port = 5000
 
 [app:main]
-use = config:../ckan/test-core.ini
+use = config:../../src/ckan/test-core.ini
 
 # Insert any custom config settings to be used when running your extension's
 # tests here.


### PR DESCRIPTION
Fixes: https://github.com/NextGeoss/nextgeoss-catalogue-issues/issues/424 and https://github.com/NextGeoss/nextgeoss-catalogue-issues/issues/426

This feature adds integration with Noa Linker Service by retrieving and displaying dataset resources retrieved from the Linker Service.

The logic was meant to be as resilient as possible. Therefore, in any situation when the linker service is not available, or no matching dataset has been found, the section to download resource is not shown. 

Also added tests to make sure all the situations when the Linker service is unavailable are covered. 

This is how it looks like when the there are resources found in the Linker Service:
![image](https://user-images.githubusercontent.com/8862002/80354992-c53fcd00-8877-11ea-9736-9228e517f0b5.png)

This is how a dataset details page looks like when there are Noa resources available:
![image](https://user-images.githubusercontent.com/8862002/80505758-0b2e8b00-8975-11ea-8dc5-c4e97001891e.png)

